### PR TITLE
As a human, I find DC Election IDs hard to read.

### DIFF
--- a/every_election/templates/home.html
+++ b/every_election/templates/home.html
@@ -20,7 +20,10 @@
                 <h3>Upcoming elections</h3>
                 <ul>
                 {% for election in upcoming_elections  %}
-                    <li><a href="{{ election.get_absolute_url }}">{{ election }}</a></li>
+                    <li>
+                        <a href="{{ election.get_absolute_url }}">{{ election }}</a> 
+                        ( {{ election.election_type }} {{ election.poll_open_date }} ) 
+                    </li>
                 {% endfor %}
                 </ul>
             </div>


### PR DESCRIPTION
Let's print the human-friendly full details next to the election ID.
Given that this is the home page, and may be accessed by people who have not internalised the One True DC Election ID Standard.