### PR TITLE
remove 'one-click DoS our own server' feature

### DIFF
--- a/every_election/apps/elections/admin.py
+++ b/every_election/apps/elections/admin.py
@@ -19,6 +19,9 @@ class ElectionAdmin(admin.ModelAdmin):
         'seats_total',
         'group',
     )
+    exclude = (
+        'geography',
+    )
 
 admin.site.register(Election, ElectionAdmin)
 admin.site.register(Explanation, MarkdownModelAdmin)


### PR DESCRIPTION
If you've got a bunch of geographies imported on your dev copy, pull this down and give it a test to make sure it actually fixes the problem. I don't have sufficient test data on my local install to notice a performance difference.