### PR TITLE
fix 'mark all seats contested' button

### DIFF
--- a/every_election/apps/elections/templates/id_creator/election_organisation_division.html
+++ b/every_election/apps/elections/templates/id_creator/election_organisation_division.html
@@ -19,9 +19,10 @@ fallback.ready(function() {
 
     $("<button type=button class=button>Mark all seats as contested (can't be undone)</button>")
     .insertAfter(".inline_radios .form-group h2").on('click', function() {
-        var container = $(this).parent();
-        var this_id = $('h2', container).attr('id');
-        $('input[id^="'+ this_id +'"][value=seats_contested]').prop("checked", true);
+        $('input[value=seats_contested]').prop("checked", true);
+        $('input[value=seats_contested]').parent().addClass("selected");
+        $('input[value=no_seats]').parent().removeClass("selected");
+        $('input[value=by_election]').parent().removeClass("selected");
     });
 });
 


### PR DESCRIPTION
I'm sure this worked at some point. Not sure which change broke it, but `$('h2', container).attr('id')` was returning `undefined`. This seems to do the job, but could do with a sanity check.