### PR TITLE
Remove duplicate code

### DIFF
--- a/every_election/apps/elections/models.py
+++ b/every_election/apps/elections/models.py
@@ -76,8 +76,6 @@ class Election(SuggestedByPublicMixin, models.Model):
     explanation = models.ForeignKey('elections.Explanation',
         null=True, blank=True, on_delete=models.SET_NULL)
     current = models.NullBooleanField()
-    explanation = models.ForeignKey('elections.Explanation',
-        null=True, blank=True, on_delete=models.SET_NULL)
 
     objects = ElectionManager.as_manager()
 


### PR DESCRIPTION
Looks like we've ended up with this declaration repeated twice as a result of some merge conflict resolution gone awry in https://github.com/DemocracyClub/EveryElection/pull/31#issuecomment-296674749 which neither of us spotted. Think the migrations were "de-duping" it for us, but it shouldn't be there.