### PR TITLE
Tests for get_notice_directory()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 language: python
 python:
@@ -5,7 +6,10 @@ python:
   - '3.5'
   - '3.4'
 addons:
-  - postgresql: '9.3'
+  postgresql: '9.3'
+  apt:
+    packages:
+      - postgresql-9.3-postgis-2.3
 cache:
   pip: true
   directories:
@@ -15,6 +19,8 @@ cache:
     - .tox
 install:
   - pip install tox tox-travis coveralls
+before_script:
+  - psql -U postgres -c "create extension postgis"
 script:
   - tox
 after_success:

--- a/every_election/apps/elections/tests/test_notice_directory.py
+++ b/every_election/apps/elections/tests/test_notice_directory.py
@@ -1,0 +1,81 @@
+from django.test import TestCase
+from elections.utils import get_notice_directory
+
+
+class IDMakerMock(object):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+election = IDMakerMock(
+    group_type='election',
+    is_group_id=True,
+    to_id=lambda: "local.election.date")
+
+organisation = IDMakerMock(
+    group_type='organisation',
+    is_group_id=True,
+    to_id=lambda: "local.election.organisation.date")
+
+ballot1 = IDMakerMock(
+    group_type='election',
+    is_group_id=False,
+    to_id=lambda: "local.election.ballot1.date")
+
+ballot2 = IDMakerMock(
+    group_type='election',
+    is_group_id=False,
+    to_id=lambda: "local.election.ballot2.date")
+
+
+class TestCreateIds(TestCase):
+
+    def test_one_ballot_with_org(self):
+        folder = get_notice_directory([
+            election,
+            organisation,
+            ballot1,
+        ])
+        self.assertEqual(ballot1.to_id(), folder)
+
+    def test_one_ballot_no_org(self):
+        folder = get_notice_directory([
+            election,
+            ballot1,
+        ])
+        self.assertEqual(ballot1.to_id(), folder)
+
+    def test_two_ballots_with_org(self):
+        folder = get_notice_directory([
+            election,
+            organisation,
+            ballot1,
+            ballot2,
+        ])
+        self.assertEqual(organisation.to_id(), folder)
+
+    def test_two_ballots_no_org(self):
+        folder = get_notice_directory([
+            election,
+            ballot1,
+            ballot2,
+        ])
+        self.assertEqual(election.to_id(), folder)
+
+    def test_group_only(self):
+        folder = get_notice_directory([
+            election,
+            organisation,
+        ])
+        self.assertEqual(organisation.to_id(), folder)
+
+    def test_invalid_empty(self):
+        with self.assertRaises(ValueError):
+            get_notice_directory([])
+
+    def test_invalid_two_ballots_no_groups(self):
+        with self.assertRaises(ValueError):
+            get_notice_directory([
+                ballot1,
+                ballot2,
+            ])


### PR DESCRIPTION
I added a bunch of code without tests the other day. This slightly improves that situation. Also some unrelated CI build fixes to account for [changes to Travis environment](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming).
