### PR TITLE
Allow a 'client' EE to sync Elections app models from a 'server' EE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ ENV/
 
 every_election/settings/local.py
 every_election/settings/production.py
+every_election/data/
 
 # collect static output directory
 every_election/static/

--- a/every_election/apps/elections/management/commands/sync_elections.py
+++ b/every_election/apps/elections/management/commands/sync_elections.py
@@ -1,0 +1,14 @@
+import tempfile
+import urllib.request
+from django.conf import settings
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        url = settings.UPSTREAM_SYNC_URL
+        with tempfile.NamedTemporaryFile(suffix='.json') as tmp:
+            urllib.request.urlretrieve(url, tmp.name)
+            call_command('loaddata', tmp.name)

--- a/every_election/apps/elections/urls.py
+++ b/every_election/apps/elections/urls.py
@@ -1,7 +1,14 @@
 from django.conf.urls import url
 
-from .views import (ElectionTypesView, AllElectionsView,
-                    IDCreatorWizard, FORMS, CONDITION_DICT, SingleElection)
+from .views import (
+    ElectionTypesView,
+    AllElectionsView,
+    IDCreatorWizard,
+    FORMS,
+    CONDITION_DICT,
+    SingleElection,
+)
+from elections.views.sync import get_election_fixture
 
 
 id_creator_wizard = IDCreatorWizard.as_view(
@@ -15,6 +22,7 @@ urlpatterns = [
     url(r'^election_types$',
         ElectionTypesView.as_view(),
         name='election_types_view'),
+
     url(r'^elections$',
         AllElectionsView.as_view(),
         name='elections_view'),
@@ -24,4 +32,6 @@ urlpatterns = [
 
     url(r'^id_creator/(?P<step>.+)/$', id_creator_wizard, name='id_creator_step'),
     url(r'^id_creator/$', id_creator_wizard, name='id_creator'),
+
+    url(r'^sync/$', get_election_fixture),
 ]

--- a/every_election/apps/elections/views/sync.py
+++ b/every_election/apps/elections/views/sync.py
@@ -1,12 +1,9 @@
-from io import StringIO
-from django.core.management import call_command
+import os
+from django.conf import settings
 from django.http import HttpResponse
 
 
 def get_election_fixture(request):
-
-    out = StringIO()
-    call_command('dumpdata', 'elections', stdout=out)
-
-    return HttpResponse(out.getvalue(),
+    out = open(os.path.join(settings.BASE_DIR, "data/elections.json")).read()
+    return HttpResponse(out,
         status=200, content_type='application/json')

--- a/every_election/apps/elections/views/sync.py
+++ b/every_election/apps/elections/views/sync.py
@@ -1,0 +1,12 @@
+from io import StringIO
+from django.core.management import call_command
+from django.http import HttpResponse
+
+
+def get_election_fixture(request):
+
+    out = StringIO()
+    call_command('dumpdata', 'elections', stdout=out)
+
+    return HttpResponse(out.getvalue(),
+        status=200, content_type='application/json')

--- a/every_election/settings/base.py
+++ b/every_election/settings/base.py
@@ -168,6 +168,8 @@ REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',)
 }
 
+UPSTREAM_SYNC_URL = 'https://elections.democracyclub.org.uk/sync/'
+
 
 AWS_ACCESS_KEY_ID = ''
 AWS_SECRET_ACCESS_KEY = ''


### PR DESCRIPTION
Having chewed over all sorts of complicated approaches to this I think the correct solution at this stage is to go with a really simple/dumb solution.. basically I've made an API endpoint which generates a fixture and serves it up and a corresponding management command which calls it and loads the fixture.

Using fixtures, `dumpdata` and `loaddata` in this way has several useful advantages:

1. `loaddata` handles some hairy stuff around FKs and statement order for us. There are problems around what order you run `DELETE`/`INSERT` statements in to ensure you aren't violating FK constraints which we just don't have to worry about with this approach.
2. Everything happens in a transaction - either the whole thing loads, or it fails and you're back where you started.
3. The "client" site/api stays responsive while the sync is happening, so we don;t have to wrry about clean/dirty flags in the "consumer" apps (unless our app already uses them for other reasons).

Obviously the tradeoff is that this isn't really re-usable by anyone else. You have to have the right magic numbers, but as we've noted we're not currently in a place where someone else can actually generate their own different magic numbers at the moment so lets focus on something that works for us rather than optimising for users we don't have yet.

Performance-wise, loading ~5,600 objects from a fixture was taking about 5 seconds locally. Its probably reasonable to expect we'll have just under double that by May next year, but obviously that number is going to keep growing with time. My inclination at this point is that for the medium-term future (the next few years?), we can probably get away with this process just being 'dumb' and syncing the entire elections app without having to be smart enough to check if it has changed first. The elections data represents less than 1% of the total database size, so getting to a point where we can build the orgs/geographies into an image and just sync the elections app nightly solves the big part of the problem. The rest is just diminishing returns at this stage.

We do need to ensure we rebuild the images when there are boundary changes + so on but I think we just deal with that in the same way as a new AddressBase release or whatever..

The next bits of this that need some work will be:

* Add an EE orgs/geography "layer" to the WhereDIV/WhoCIVF `packer` builds
* Find a way to "randomise" the syncing on the "client" end - I'm not particularly worried about this from the perspective of the clients staying responsive now as they seem to continue happily serving requests while the `loaddata` is happening, but `/sync` is a reasonably heavyweight endpoint and I'd rather not have 10 servers all request it at once..
