### PR TITLE
fix Lib Dem Newbies scraper error

### DIFF
--- a/every_election/apps/election_snooper/snoopers/lib_dem_newbies.py
+++ b/every_election/apps/election_snooper/snoopers/lib_dem_newbies.py
@@ -25,7 +25,11 @@ class LibDemNewbiesScraper(BaseSnooper):
             content = tile.text
 
             if 'cause' in content.lower():
-                cause = re.match(".*\n(\S+) seat. [cC]ause: (\S+)\n.*", content).group(2)
+                try:
+                    cause = re.match(
+                        ".*\n(\S+) seat. [cC]ause: (\S+)\n.*", content).group(2)
+                except AttributeError:
+                    cause = "unknown"
             else:
                 cause = "unknown"
 


### PR DESCRIPTION
Lib Dem Newbies scraper started throwing `AttributeError: 'NoneType' object has no attribute 'group'` last night..