### PR TITLE
Refactor IDMaker

### DIFF
--- a/every_election/apps/elections/templates/id_creator/review.html
+++ b/every_election/apps/elections/templates/id_creator/review.html
@@ -10,21 +10,21 @@ and replace it with the date when it's known.</p>
 
 
 <h2>Group IDs</h2>
-{% for election_id in all_ids %}
-    {% if election_id.is_group_id %}
-    <h3><code>{{ election_id.to_id }}</code></h3>
+{% for election in all_ids %}
+    {% if election.group_type %}
+    <h3><code>{{ election.election_id }}</code></h3>
     {% endif %}
 {% endfor %}
 
 
 <h2>Ballot paper IDs</h2>
-{% regroup all_ids by to_title as elections_by_title %}
+{% regroup all_ids by election_title as elections_by_title %}
 {% for election_group in elections_by_title %}
     {% if election_group.grouper %}
     <h3>{{ election_group.grouper }}</h3>
-    {% for election_id in election_group.list %}
-        {% if not election_id.is_group_id %}
-        <h3><code>{{ election_id.to_id }}</code></h3>
+    {% for election in election_group.list %}
+        {% if not election.group_type %}
+        <h3><code>{{ election.election_id }}</code></h3>
         {% endif %}
     {% endfor %}
     {% endif %}

--- a/every_election/apps/elections/tests/base_tests.py
+++ b/every_election/apps/elections/tests/base_tests.py
@@ -69,5 +69,5 @@ class BaseElectionCreatorMixIn():
     def create_ids(self, all_data, save_model=True, **kwargs):
         all_ids = create_ids_for_each_ballot_paper(all_data, **kwargs)
         if save_model:
-            [e_id.save_model() for e_id in all_ids]
+            [e_id.save() for e_id in all_ids]
 

--- a/every_election/apps/elections/tests/test_create_ids.py
+++ b/every_election/apps/elections/tests/test_create_ids.py
@@ -1,8 +1,10 @@
 from django.test import TestCase
 
-from elections.models import Election, ElectionType, ElectionSubType
+from elections.models import (
+    ElectedRole, Election, ElectionType, ElectionSubType)
 from elections.utils import create_ids_for_each_ballot_paper
-from organisations.models import Organisation, DivisionGeography
+from organisations.models import (
+    Organisation, OrganisationDivision, DivisionGeography)
 
 from .base_tests import BaseElectionCreatorMixIn
 
@@ -123,6 +125,12 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
         mayor_election_type = ElectionType.objects.get(
             election_type='mayor',
         )
+        ElectedRole.objects.create(
+            election_type=mayor_election_type,
+            organisation=mayor_org,
+            elected_title="Mayor",
+            elected_role_name="Mayor of Foo Town",
+        )
 
 
         all_data =  {
@@ -184,10 +192,20 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
         naw_election_type = ElectionType.objects.get(
             election_type='naw',
         )
-
         naw_election_sub_type = ElectionSubType.objects.get(
             election_subtype='c',
             election_type=naw_election_type,
+        )
+        ElectedRole.objects.create(
+            election_type=naw_election_type,
+            organisation=naw_org,
+            elected_title="Assembly Member",
+            elected_role_name="Assembly Member for Foo",
+        )
+        org_div_3 = OrganisationDivision.objects.create(
+            organisation=naw_org,
+            name="Test Div 3",
+            slug="test-div-3"
         )
 
 
@@ -199,12 +217,12 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
         }
 
         all_data.update({
-            self.make_div_id(org=naw_org): 'contested',
+            self.make_div_id(org=naw_org, div=org_div_3): 'contested',
         })
 
         expected_ids = [
             'naw.'+self.date_str,
-            'naw.c.test-div.'+self.date_str,
+            'naw.c.test-div-3.'+self.date_str,
         ]
 
         self.run_test_with_data(

--- a/every_election/apps/elections/tests/test_create_ids.py
+++ b/every_election/apps/elections/tests/test_create_ids.py
@@ -214,6 +214,11 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             name="Test Div 3",
             slug="test-div-3"
         )
+        org_div_4 = OrganisationDivision.objects.create(
+            organisation=naw_org,
+            name="Test Div 4",
+            slug="test-div-4"
+        )
 
 
         all_data =  {
@@ -224,12 +229,16 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
         }
 
         all_data.update({
-            self.make_div_id(org=naw_org, div=org_div_3): 'contested',
+            self.make_div_id(
+                org=naw_org, div=org_div_3): 'contested',  # contested seat
+            self.make_div_id(
+                org=naw_org, div=org_div_4): 'by_election',  # by election
         })
 
         expected_ids = [
             'naw.'+self.date_str,
-            'naw.c.test-div-3.'+self.date_str,
+            'naw.c.test-div-3.'+self.date_str,  # no 'by' suffix
+            'naw.c.test-div-4.by.'+self.date_str,  # 'by' suffix
         ]
 
         self.run_test_with_data(

--- a/every_election/apps/elections/tests/test_create_ids.py
+++ b/every_election/apps/elections/tests/test_create_ids.py
@@ -2,7 +2,6 @@ from django.test import TestCase
 
 from elections.models import (
     ElectedRole, Election, ElectionType, ElectionSubType)
-from elections.utils import create_ids_for_each_ballot_paper
 from organisations.models import (
     Organisation, OrganisationDivision, DivisionGeography)
 

--- a/every_election/apps/elections/tests/test_create_ids.py
+++ b/every_election/apps/elections/tests/test_create_ids.py
@@ -14,8 +14,15 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
     def run_test_with_data(self, all_data, expected_ids, **kwargs):
         self.create_ids(all_data, **kwargs)
         assert Election.objects.count() == len(expected_ids)
+
+        # ensure the records created match the expected ids
         for expected_id in expected_ids:
             assert Election.objects.filter(election_id=expected_id).exists()
+
+        # ensure group relationships have been saved correctly
+        for election in Election.objects.all():
+            if election.group_type != 'election':
+                assert isinstance(election.group_id, int)
 
     def test_group_id(self):
         self.run_test_with_data(

--- a/every_election/apps/elections/tests/test_create_ids.py
+++ b/every_election/apps/elections/tests/test_create_ids.py
@@ -21,14 +21,6 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             ['local.'+self.date_str, ]
         )
 
-    def test_id_repr_and_eq(self):
-        all_data = self.base_data
-        all_data.update({self.make_div_id(): 'contested'})
-        ids = create_ids_for_each_ballot_paper(all_data)
-        assert repr(ids[0]) == "local.{}".format(self.date_str)
-        assert ids[0] != ids[1]
-
-
     def test_creates_div_data_ids(self):
         self.assertEqual(Election.objects.count(), 0)
         all_data = self.base_data

--- a/every_election/apps/elections/tests/test_election_builder.py
+++ b/every_election/apps/elections/tests/test_election_builder.py
@@ -1,9 +1,10 @@
 from django.test import TestCase
 from elections.utils import ElectionBuilder
 from organisations.tests.factories import OrganisationFactory
+from .base_tests import BaseElectionCreatorMixIn
 
 
-class TestElectionBuilder(TestCase):
+class TestElectionBuilder(BaseElectionCreatorMixIn, TestCase):
 
     def test_eq(self):
         eb1 = ElectionBuilder('local', '2017-06-08')
@@ -15,8 +16,7 @@ class TestElectionBuilder(TestCase):
         # these should be 'equal' because only the meta-data differs
         self.assertEqual(eb1, eb2)
 
-        eb2 = eb2.with_organisation(
-            OrganisationFactory(territory_code="SCT", gss="S0000001"))
+        eb2 = eb2.with_organisation(self.org1)
 
         # now these objects will build funamentally different elections
         self.assertNotEqual(eb1, eb2)

--- a/every_election/apps/elections/tests/test_election_builder.py
+++ b/every_election/apps/elections/tests/test_election_builder.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+from elections.utils import ElectionBuilder
+from organisations.tests.factories import OrganisationFactory
+
+
+class TestElectionBuilder(TestCase):
+
+    def test_eq(self):
+        eb1 = ElectionBuilder('local', '2017-06-08')
+
+        eb2 = ElectionBuilder('local', '2017-06-08')\
+            .with_source('foo/bar.baz')\
+            .with_snooped_election(7)
+
+        # these should be 'equal' because only the meta-data differs
+        self.assertEqual(eb1, eb2)
+
+        eb2 = eb2.with_organisation(
+            OrganisationFactory(territory_code="SCT", gss="S0000001"))
+
+        # now these objects will build funamentally different elections
+        self.assertNotEqual(eb1, eb2)

--- a/every_election/apps/elections/tests/test_election_builder.py
+++ b/every_election/apps/elections/tests/test_election_builder.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 from elections.utils import ElectionBuilder
+from election_snooper.models import SnoopedElection
 from organisations.tests.factories import OrganisationFactory
 from .base_tests import BaseElectionCreatorMixIn
 
@@ -20,3 +21,15 @@ class TestElectionBuilder(BaseElectionCreatorMixIn, TestCase):
 
         # now these objects will build funamentally different elections
         self.assertNotEqual(eb1, eb2)
+
+    def test_with_metadata(self):
+        snooper = SnoopedElection.objects.create()
+        builder = ElectionBuilder('local', '2017-06-08')\
+            .with_organisation(self.org1)\
+            .with_division(self.org_div_1)\
+            .with_source('foo/bar.baz')\
+            .with_snooped_election(snooper.id)
+        election = builder.build_ballot(None)
+        election.save()
+        self.assertEqual('foo/bar.baz', election.source)
+        assert isinstance(election.snooped_election, SnoopedElection)

--- a/every_election/apps/elections/tests/test_election_builder.py
+++ b/every_election/apps/elections/tests/test_election_builder.py
@@ -1,7 +1,8 @@
 from django.test import TestCase
+from elections.models import ElectionType, ElectionSubType, ElectedRole
 from elections.utils import ElectionBuilder
 from election_snooper.models import SnoopedElection
-from organisations.tests.factories import OrganisationFactory
+from organisations.models import Organisation
 from .base_tests import BaseElectionCreatorMixIn
 
 
@@ -33,3 +34,48 @@ class TestElectionBuilder(BaseElectionCreatorMixIn, TestCase):
         election.save()
         self.assertEqual('foo/bar.baz', election.source)
         assert isinstance(election.snooped_election, SnoopedElection)
+
+    def test_invalid_subtype(self):
+        naw_election_type = ElectionType.objects.get(
+            election_type='naw',
+        )
+        invalid_sub_type = ElectionSubType.objects.create(
+            election_subtype='x',
+            election_type=self.election_type1,
+        )
+        builder = ElectionBuilder(naw_election_type, '2017-06-08')
+        with self.assertRaises(ValueError):
+            builder.with_subtype(invalid_sub_type)
+
+    def test_invalid_organisation(self):
+        builder = ElectionBuilder('local', '2017-06-08')
+
+        # delete the relationship between org1 and local elections
+        self.elected_role1.delete()
+
+        with self.assertRaises(ValueError):
+            builder.with_organisation(self.org1)
+
+    def test_invalid_division(self):
+        org2 = Organisation.objects.create(
+            official_identifier='TEST2',
+            organisation_type='local-authority',
+            official_name="Test Council",
+            gss="X00000003",
+            slug="test2",
+            territory_code="ENG",
+            election_name="Test2 Council Local Elections",
+        )
+        ElectedRole.objects.create(
+            election_type=self.election_type1,
+            organisation=org2,
+            elected_title="Local Councillor",
+            elected_role_name="Councillor for Test2 Council",
+        )
+        builder = ElectionBuilder('local', '2017-06-08')\
+            .with_organisation(org2)
+
+        # self.org_div_1 is not a child of org2
+        # its a child of self.org1
+        with self.assertRaises(ValueError):
+            builder.with_division(self.org_div_1)

--- a/every_election/apps/elections/tests/test_election_model.py
+++ b/every_election/apps/elections/tests/test_election_model.py
@@ -1,0 +1,58 @@
+from django.test import TestCase
+from elections.models import Election
+from elections.utils import ElectionBuilder
+from .base_tests import BaseElectionCreatorMixIn
+
+
+class TestElectionModel(BaseElectionCreatorMixIn, TestCase):
+
+    def setUp(self):
+        super().setUp()
+        Election.objects.all().delete()
+        self.parent_election = ElectionBuilder('local', '2017-06-08')\
+                .build_election_group()
+        self.child_election = ElectionBuilder('local', '2017-06-08')\
+                .with_organisation(self.org1)\
+                .build_organisation_group(self.parent_election)
+
+    def test_recursive_save(self):
+        # table should be empty before we start
+        self.assertEqual(0, Election.objects.count())
+
+        # saving the child record should implicitly save the parent record too
+        self.child_election.save()
+        self.assertEqual(2, Election.objects.count())
+
+    def test_transaction_rollback_parent(self):
+        # table should be empty before we start
+        self.assertEqual(0, Election.objects.count())
+
+        # doing this will cause save() to throw a exception
+        # if we try to save parent_record
+        self.parent_election.organisation_id = "foo"
+
+        try:
+            self.child_election.save()
+        except ValueError:
+            pass
+
+        # the exception should have prevented both the
+        # parent and child records from being saved
+        self.assertEqual(0, Election.objects.count())
+
+    def test_transaction_rollback_child(self):
+        # table should be empty before we start
+        self.assertEqual(0, Election.objects.count())
+
+        # doing this will cause save() to throw a exception
+        # if we try to save child_record
+        self.child_election.organisation_id = "foo"
+
+        try:
+            self.child_election.save()
+        except ValueError:
+            pass
+
+        # the exception should have prevented both the
+        # parent and child records from being saved
+        self.assertEqual(0, Election.objects.count())

--- a/every_election/apps/elections/tests/test_notice_directory.py
+++ b/every_election/apps/elections/tests/test_notice_directory.py
@@ -2,30 +2,13 @@ from django.test import TestCase
 from elections.utils import get_notice_directory
 from elections.utils import ElectionBuilder
 from organisations.models import Organisation, OrganisationDivision
+from .base_tests import BaseElectionCreatorMixIn
 
 
-class TestCreateIds(TestCase):
+class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
 
     def setUp(self):
-        org = Organisation.objects.create(
-            official_identifier='TEST1',
-            organisation_type='local-authority',
-            official_name="Test Council",
-            gss="X00000001",
-            slug="test",
-            territory_code="ENG",
-            election_name="Test Council Local Elections",
-        )
-        org_div_1 = OrganisationDivision.objects.create(
-            organisation=org,
-            name="Test Div 1",
-            slug="test-div"
-        )
-        org_div_2 = OrganisationDivision.objects.create(
-            organisation=org,
-            name="Test Div 2",
-            slug="test-div-2"
-        )
+        super().setUp()
 
         self.election = \
             ElectionBuilder('local', '2017-06-08')\
@@ -33,19 +16,19 @@ class TestCreateIds(TestCase):
 
         self.organisation =\
             ElectionBuilder('local', '2017-06-08')\
-                .with_organisation(org)\
+                .with_organisation(self.org1)\
                 .build_organisation_group(None)
 
         self.ballot1 =\
             ElectionBuilder('local', '2017-06-08')\
-                .with_organisation(org)\
-                .with_division(org_div_1)\
+                .with_organisation(self.org1)\
+                .with_division(self.org_div_1)\
                 .build_ballot(None)
 
         self.ballot2 =\
             ElectionBuilder('local', '2017-06-08')\
-                .with_organisation(org)\
-                .with_division(org_div_2)\
+                .with_organisation(self.org1)\
+                .with_division(self.org_div_2)\
                 .build_ballot(None)
 
     def test_one_ballot_with_org(self):

--- a/every_election/apps/elections/tests/test_notice_directory.py
+++ b/every_election/apps/elections/tests/test_notice_directory.py
@@ -1,7 +1,6 @@
 from django.test import TestCase
 from elections.utils import get_notice_directory
 from elections.utils import ElectionBuilder
-from organisations.models import Organisation, OrganisationDivision
 from .base_tests import BaseElectionCreatorMixIn
 
 

--- a/every_election/apps/elections/tests/test_notice_directory.py
+++ b/every_election/apps/elections/tests/test_notice_directory.py
@@ -1,73 +1,91 @@
 from django.test import TestCase
 from elections.utils import get_notice_directory
-
-
-class IDMakerMock(object):
-    def __init__(self, **kwargs):
-        self.__dict__.update(kwargs)
-
-
-election = IDMakerMock(
-    group_type='election',
-    is_group_id=True,
-    to_id=lambda: "local.election.date")
-
-organisation = IDMakerMock(
-    group_type='organisation',
-    is_group_id=True,
-    to_id=lambda: "local.election.organisation.date")
-
-ballot1 = IDMakerMock(
-    group_type='election',
-    is_group_id=False,
-    to_id=lambda: "local.election.ballot1.date")
-
-ballot2 = IDMakerMock(
-    group_type='election',
-    is_group_id=False,
-    to_id=lambda: "local.election.ballot2.date")
+from elections.utils import ElectionBuilder
+from organisations.models import Organisation, OrganisationDivision
 
 
 class TestCreateIds(TestCase):
 
+    def setUp(self):
+        org = Organisation.objects.create(
+            official_identifier='TEST1',
+            organisation_type='local-authority',
+            official_name="Test Council",
+            gss="X00000001",
+            slug="test",
+            territory_code="ENG",
+            election_name="Test Council Local Elections",
+        )
+        org_div_1 = OrganisationDivision.objects.create(
+            organisation=org,
+            name="Test Div 1",
+            slug="test-div"
+        )
+        org_div_2 = OrganisationDivision.objects.create(
+            organisation=org,
+            name="Test Div 2",
+            slug="test-div-2"
+        )
+
+        self.election = \
+            ElectionBuilder('local', '2017-06-08')\
+                .build_election_group()
+
+        self.organisation =\
+            ElectionBuilder('local', '2017-06-08')\
+                .with_organisation(org)\
+                .build_organisation_group(None)
+
+        self.ballot1 =\
+            ElectionBuilder('local', '2017-06-08')\
+                .with_organisation(org)\
+                .with_division(org_div_1)\
+                .build_ballot(None)
+
+        self.ballot2 =\
+            ElectionBuilder('local', '2017-06-08')\
+                .with_organisation(org)\
+                .with_division(org_div_2)\
+                .build_ballot(None)
+
     def test_one_ballot_with_org(self):
         folder = get_notice_directory([
-            election,
-            organisation,
-            ballot1,
+            self.election,
+            self.organisation,
+            self.ballot1,
         ])
-        self.assertEqual(ballot1.to_id(), folder)
+        self.assertEqual(self.ballot1.election_id, folder)
 
     def test_one_ballot_no_org(self):
         folder = get_notice_directory([
-            election,
-            ballot1,
+            self.election,
+            self.ballot1,
         ])
-        self.assertEqual(ballot1.to_id(), folder)
+        self.assertEqual(self.ballot1.election_id, folder)
 
     def test_two_ballots_with_org(self):
         folder = get_notice_directory([
-            election,
-            organisation,
-            ballot1,
-            ballot2,
+            self.election,
+            self.organisation,
+            self.ballot1,
+            self.ballot2,
         ])
-        self.assertEqual(organisation.to_id(), folder)
+        self.assertEqual(self.organisation.election_id, folder)
 
     def test_two_ballots_no_org(self):
         folder = get_notice_directory([
-            election,
-            ballot1,
-            ballot2,
+            self.election,
+            self.ballot1,
+            self.ballot2,
         ])
-        self.assertEqual(election.to_id(), folder)
+        self.assertEqual(self.election.election_id, folder)
 
     def test_group_only(self):
         folder = get_notice_directory([
-            election,
-            organisation,
+            self.election,
+            self.organisation,
         ])
-        self.assertEqual(organisation.to_id(), folder)
+        self.assertEqual(self.organisation.election_id, folder)
 
     def test_invalid_empty(self):
         with self.assertRaises(ValueError):
@@ -76,6 +94,6 @@ class TestCreateIds(TestCase):
     def test_invalid_two_ballots_no_groups(self):
         with self.assertRaises(ValueError):
             get_notice_directory([
-                ballot1,
-                ballot2,
+                self.ballot1,
+                self.ballot2,
             ])

--- a/every_election/apps/elections/tests/test_voting_systems.py
+++ b/every_election/apps/elections/tests/test_voting_systems.py
@@ -1,7 +1,6 @@
 from django.test import TestCase
 
-# from elections.models import Election
-from elections.utils import IDMaker
+from elections.utils import ElectionBuilder
 
 from .base_tests import BaseElectionCreatorMixIn
 from organisations.tests.factories import OrganisationFactory
@@ -16,7 +15,8 @@ class TestElectoralSystems(BaseElectionCreatorMixIn, TestCase):
         """
 
         # "Normal" UK local election is FPTP
-        election_id = IDMaker('local', '2017-05-04')
+        election_id = ElectionBuilder('local', '2017-05-04')\
+            .build_election_group()
         assert election_id.voting_system.slug == "FPTP"
 
         scot_org = OrganisationFactory(
@@ -25,5 +25,7 @@ class TestElectoralSystems(BaseElectionCreatorMixIn, TestCase):
         )
 
         # Scotish local elections are STV
-        scot_id = IDMaker('local', '2017-05-04', organisation=scot_org)
+        scot_id = ElectionBuilder('local', '2017-05-04')\
+            .with_organisation(scot_org)\
+            .build_organisation_group(None)
         assert scot_id.voting_system.slug == "STV"

--- a/every_election/apps/elections/tests/test_voting_systems.py
+++ b/every_election/apps/elections/tests/test_voting_systems.py
@@ -3,8 +3,8 @@ from django.test import TestCase
 from elections.utils import ElectionBuilder
 
 from .base_tests import BaseElectionCreatorMixIn
+from elections.models import ElectedRole
 from organisations.tests.factories import OrganisationFactory
-
 
 
 class TestElectoralSystems(BaseElectionCreatorMixIn, TestCase):
@@ -22,6 +22,13 @@ class TestElectoralSystems(BaseElectionCreatorMixIn, TestCase):
         scot_org = OrganisationFactory(
             territory_code="SCT",
             gss="S0000001"
+        )
+
+        ElectedRole.objects.create(
+            election_type=self.election_type1,
+            organisation=scot_org,
+            elected_title="MSP",
+            elected_role_name="MSP for Foo Town",
         )
 
         # Scotish local elections are STV

--- a/every_election/apps/elections/utils.py
+++ b/every_election/apps/elections/utils.py
@@ -230,7 +230,7 @@ def create_ids_for_each_ballot_paper(all_data, subtypes=None):
             else:
                 group_id = date_id
 
-        if all_data['election_type'].election_type == "mayor":
+        if all_data['election_type'].election_type in ["mayor", "pcc"]:
             group_id = date_id
             mayor_id = ElectionBuilder(
                 all_data['election_type'], all_data['date'])\

--- a/every_election/apps/elections/utils.py
+++ b/every_election/apps/elections/utils.py
@@ -202,11 +202,6 @@ def create_ids_for_each_ballot_paper(all_data, subtypes=None):
             and v != ""
         }
 
-        args = [all_data['election_type'], all_data['date']]
-        kwargs = {
-            'organisation': organisation,
-        }
-
         election_type = all_data['election_type'].election_type
         organisation_type = organisation.organisation_type
 

--- a/every_election/apps/elections/utils.py
+++ b/every_election/apps/elections/utils.py
@@ -118,7 +118,14 @@ class IDMaker(object):
             if not group_model:
                 group_model = self.group_id.save_model()
 
-        default_kwargs = {
+        try:
+            return Election.objects.get(election_id=self.to_id())
+        except Election.DoesNotExist:
+            pass
+
+        return Election.objects.create(**{
+            'election_id': self.to_id(),
+            'poll_open_date': self.date,
             'election_type':  self.election_type,
             'election_title': self.to_title(),
             'election_subtype':  self.subtype,
@@ -131,27 +138,7 @@ class IDMaker(object):
             'notice': self.notice,
             'source': self.source,
             'snooped_election_id': self.snooped_election_id,
-        }
-
-        try:
-            existing_model = Election.objects.get(
-                election_id=None,
-                **default_kwargs
-            )
-            self.model = existing_model
-        except Election.DoesNotExist:
-            existing_model = None
-
-        if existing_model:
-            existing_model.poll_open_date = self.date
-            existing_model.election_id = self.to_id()
-            existing_model.save()
-            return existing_model
-        else:
-            default_kwargs['poll_open_date'] = self.date
-            new_model, _ = Election.objects.update_or_create(
-                election_id=self.to_id(), defaults=default_kwargs)
-            return new_model
+        })
 
 
 def create_ids_for_each_ballot_paper(all_data, subtypes=None):

--- a/every_election/apps/elections/views/id_creator.py
+++ b/every_election/apps/elections/views/id_creator.py
@@ -241,11 +241,11 @@ class IDCreatorWizard(NamedUrlSessionWizardView):
                 # because we can't make a safe assumption about whether
                 # all of the elections in a group are covered by a single
                 # Notice of Election document - it will vary
-                if not election.is_group_id:
+                if not election.group_type:
                     election.notice = doc
 
         for election in context['all_ids']:
-            election.save_model()
+            election.save()
 
         # if this election was created from a radar entry set the status
         # of the radar entry to indicate we have made an id for it


### PR DESCRIPTION
Refs #70
Continued from PR #97

The is the next step in the task of refactoring the Election creation process. In the previous PR I split out the process of creating an Election ID string into the `IdBuilder` class. This PR splits the remains of `IDMaker` into `ElectionBuilder` (which we use to create an `Election` object and has a consistent interface with `IdBuilder`) and moves the database persistance code over to the `Election` model object itself. This also allows us to pass around and review an `Election` object which we can then persist if we're happy with it, rather than passing around and reviewing a proxy object which may persist an `Election`, which I think is conceptually nicer.

Most of the action is in 2760de6 - sorry this commit is a bit large but it was quite difficult to do this in multiple smaller stages :(

5f70c22 adds the validation checks we talked about in https://github.com/DemocracyClub/EveryElection/pull/97#issuecomment-342475799 . Conceptually I think this layer is the correct place for this validation to live. In the end, I structured it using composition rather than inheritance (i.e: an `ElectionBuilder` *has a* `IdBuilder` as opposed to `ElectionBuilder` *is a special* `IdBuilder`), which I think is more correct conceptually but it gets us to roughly the same outcome we discussed.

As with PR #97, I've tried to constrain the scope of this a bit so I've tried not to change `create_ids_for_each_ballot_paper()` too much in this PR. The final step of this piece of work will be to tidy that function up a bit. I think broadly the scope of it (as an interface between the form wizard and the `ElectionBuilder`) is ok, but there might now be scope to write some of it a bit more nicely.

Also tests - lots of tests