### PR TITLE
fix duplicate key error creating elections in >1 org

### DIFF
--- a/every_election/apps/elections/utils.py
+++ b/every_election/apps/elections/utils.py
@@ -209,7 +209,7 @@ def create_ids_for_each_ballot_paper(all_data, subtypes=None):
         # Make a group ID for the date and election type
         date_id = ElectionBuilder(all_data['election_type'], all_data['date'])\
             .build_election_group()
-        if date_id not in all_ids:
+        if date_id.election_id not in [e.election_id for e in all_ids]:
             all_ids.append(date_id)
 
         # GROUP 2
@@ -220,7 +220,7 @@ def create_ids_for_each_ballot_paper(all_data, subtypes=None):
                     all_data['election_type'], all_data['date'])\
                     .with_organisation(organisation)\
                     .build_organisation_group(date_id)
-                if group_id not in all_ids:
+                if group_id.election_id not in [e.election_id for e in all_ids]:
                     all_ids.append(group_id)
             else:
                 group_id = date_id
@@ -233,7 +233,7 @@ def create_ids_for_each_ballot_paper(all_data, subtypes=None):
                 .with_source(all_data.get('source', ''))\
                 .with_snooped_election(all_data.get('radar_id', None))\
                 .build_ballot(group_id)
-            if mayor_id not in all_ids:
+            if mayor_id.election_id not in [e.election_id for e in all_ids]:
                 all_ids.append(mayor_id)
 
         if subtypes:


### PR DESCRIPTION
Closes #115

This was actually a slightly different issue than what I suggested it might be in https://github.com/DemocracyClub/EveryElection/issues/115#issuecomment-350285758

Because `all_ids` now contains a list of `Election` objects which haven't been persisted to the DB yet conditions like `if date_id not in all_ids` were always evaluating to `False` (2 django models are only equal if they have been persisted to the DB and have the same primary key. If they haven't been persisted yet, they are considered not equal even if every field contains the same data). Bit of a 4pm on Friday fix, but I've ammended this to compare the id fields which fixes the regression and restores the intended behaviour.

As future work we should:

1. Add some test cases for multiple elections: I broke this and no tests failed.
2. See if I can do this in a slightly nicer way when I look at refactoring `create_ids_for_each_ballot_paper()`. We can probably populate a `set()` as we go or something rather than assembling a new list of id strings each time we do the check.