### PR TITLE
Always get the organisation objects from that database

### DIFF
--- a/every_election/apps/elections/views/id_creator.py
+++ b/every_election/apps/elections/views/id_creator.py
@@ -189,6 +189,8 @@ class IDCreatorWizard(NamedUrlSessionWizardView):
         if not 'date' in all_data:
             all_data['date'] = None
 
+        all_data['election_organisation'] = self.get_organisations()
+
         if not all_data.get('election_organisation'):
             all_data.update(self.storage.extra_data)
         else:


### PR DESCRIPTION
Quick fix that's needed because of removing the code that converted org types to org objects in #114.

We should talk about the lines below it though, as I'm not sure what they're doing:

```python
if not all_data.get('election_organisation'):
    all_data.update(self.storage.extra_data)
else:
    all_data['radar_id'] = self.storage.extra_data.get('radar_id', None)
```