### PR TITLE
Fix 'Mark all seats as contested' buttons

### DIFF
--- a/every_election/apps/elections/templates/id_creator/election_organisation_division.html
+++ b/every_election/apps/elections/templates/id_creator/election_organisation_division.html
@@ -17,16 +17,17 @@
 <script>
 fallback.ready(function() {
 
-    $("<button type=button class=button>Mark all seats as contested (can't be undone)</button>")
-    .insertAfter(".inline_radios .form-group h2").on('click', function() {
-        $('input[value=seats_contested]').prop("checked", true);
-        $('input[value=seats_contested]').parent().addClass("selected");
-        $('input[value=no_seats]').parent().removeClass("selected");
-        $('input[value=by_election]').parent().removeClass("selected");
-    });
-});
+    $("form").prepend(
+      $("<button type='button' class='button'>Mark all seats as contested (can't be undone)</button>")
+        .on('click', function() {
+          $('input[value=seats_contested]').prop("checked", true);
+          $('input[value=seats_contested]').parent().addClass("selected");
+          $('input[value=no_seats]').parent().removeClass("selected");
+          $('input[value=by_election]').parent().removeClass("selected");
+        })
+    );
 
-// });
+});
 
 </script>
 {% endblock extra_javascript %}


### PR DESCRIPTION
This PR replaces the multiple 'Mark all seats as contested' buttons attached to each header with a single 'Mark all seats as contested' button for the whole page. This fixes the problems in https://github.com/DemocracyClub/EveryElection/pull/114#discussion_r155789081 and #116 . In principle its a bit less flexible but in practice, I don't think the old buttons actually worked as intended anyway.

The only situation where this is still a bit odd is where we try to create an election and there are >0 orgs but 0 divisions available, but in general this is an improvement and fixes several problems.

I've intentionally done this by defining a django `SelectAllButtonField` form field rather than doing this in pure JS so that if we really want to put work into a more fine-grained approach, we can choose to conditionally create or not create `SelectAllButtonField`s based on conditions we encounter in the constructor of `ElectionOrganisationDivisionForm`. Note this would also require some additional fiddling to allow us to pick up which radio buttons relate to a particular organisation via javascript on the front-end.

Closes #116

