### PR TITLE
Create Election records for subtype groups

### DIFF
--- a/every_election/apps/api/serializers.py
+++ b/every_election/apps/api/serializers.py
@@ -143,7 +143,7 @@ class ElectionSerializer(serializers.HyperlinkedModelSerializer):
         return obj.get_current
 
     def get_voting_system(self, obj):
-        if obj.group_type == 'organisation' or not obj.group_type:
+        if obj.group_type == 'organisation' or obj.group_type == 'subtype' or not obj.group_type:
             return VotingSystemSerializer(obj.voting_system).data
         return None
 

--- a/every_election/apps/elections/tests/test_create_ids.py
+++ b/every_election/apps/elections/tests/test_create_ids.py
@@ -221,6 +221,7 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
 
         expected_ids = [
             'naw.'+self.date_str,
+            'naw.c.'+self.date_str,
             'naw.c.test-div-3.'+self.date_str,  # no 'by' suffix
             'naw.c.test-div-4.by.'+self.date_str,  # 'by' suffix
         ]

--- a/every_election/apps/elections/utils.py
+++ b/every_election/apps/elections/utils.py
@@ -175,6 +175,16 @@ class ElectionBuilder:
             'snooped_election_id': None,
         })
 
+    def build_subtype_group(self, group):
+        return self._build({
+            'election_id': self.id.subtype_group_id,
+            'group': group,
+            'group_type': 'subtype',
+            'notice': None,
+            'source': '',
+            'snooped_election_id': None,
+        })
+
     def build_organisation_group(self, group):
         return self._build({
             'election_id': self.id.organisation_group_id,
@@ -247,6 +257,15 @@ def create_ids_for_each_ballot_paper(all_data, subtypes=None):
 
         if subtypes:
             for subtype in all_data.get('election_subtype', []):
+
+                subtype_id = ElectionBuilder(
+                    all_data['election_type'], all_data['date'])\
+                    .with_subtype(subtype)\
+                    .with_source(all_data.get('source', ''))\
+                    .with_snooped_election(all_data.get('radar_id', None))\
+                    .build_subtype_group(group_id)
+                all_ids.append(subtype_id)
+
                 for div, contest_type in div_data.items():
                     org_div = OrganisationDivision.objects.get(
                         pk=div.split('__')[1]
@@ -262,9 +281,9 @@ def create_ids_for_each_ballot_paper(all_data, subtypes=None):
 
                     if contest_type == 'by_election':
                         all_ids.append(
-                            builder.with_contest_type('by').build_ballot(group_id))
+                            builder.with_contest_type('by').build_ballot(subtype_id))
                     elif contest_type in ['contested', 'seats_contested']:
-                        all_ids.append(builder.build_ballot(group_id))
+                        all_ids.append(builder.build_ballot(subtype_id))
                     else:
                         raise ValueError("Unrecognised contest_type value '%s'" % contest_type)
         else:

--- a/every_election/apps/uk_election_ids/election_ids.py
+++ b/every_election/apps/uk_election_ids/election_ids.py
@@ -120,6 +120,25 @@ class IdBuilder:
         parts.append(self.date)
         return ".".join(parts)
 
+    def _validate_for_subtype_group_id(self):
+        if not isinstance(self.spec.subtypes, tuple):
+            raise ValueError("Can't create subtype id for election_type %s" % (self.election_type))
+        if isinstance(self.spec.subtypes, tuple) and not self.subtype:
+            raise ValueError("Subtype must be specified for election_type %s" % (self.election_type))
+        self._validate_subtype(self.subtype)
+        return True
+
+    @property
+    def subtype_group_id(self):
+        self._validate()
+        self._validate_for_subtype_group_id()
+
+        parts = []
+        parts.append(self.election_type)
+        parts.append(self.subtype)
+        parts.append(self.date)
+        return ".".join(parts)
+
     def _validate_for_organisation_group_id(self):
         # validation checks specifically relevant to creating an organisation group id
         if isinstance(self.spec.subtypes, tuple) and not self.subtype:
@@ -129,6 +148,7 @@ class IdBuilder:
             raise ValueError("election_type %s can not have an organisation group id" % (self.election_type))
         if self.spec.can_have_orgs and not self.organisation:
             raise ValueError("election_type %s must have an organisation in order to create an organisation group id" % (self.election_type))
+        return True
 
     @property
     def organisation_group_id(self):
@@ -181,6 +201,12 @@ class IdBuilder:
             ids.append(self.election_group_id)
         except ValueError:
             pass
+
+        if isinstance(self.spec.subtypes, tuple):
+            try:
+                ids.append(self.subtype_group_id)
+            except ValueError:
+                pass
 
         if self.spec.can_have_orgs:
             try:

--- a/every_election/apps/uk_election_ids/tests/test_id_builder.py
+++ b/every_election/apps/uk_election_ids/tests/test_id_builder.py
@@ -27,6 +27,8 @@ class TestIdBuilder(TestCase):
             election_id = id.election_group_id
             self.assertEqual("%s.2018-05-03" % (election_type), election_id)
             with self.assertRaises(ValueError):
+                id.subtype_group_id
+            with self.assertRaises(ValueError):
                 id.organisation_group_id
             with self.assertRaises(ValueError):
                 id.ballot_id
@@ -44,12 +46,15 @@ class TestIdBuilder(TestCase):
                 .with_subtype('c')
             election_id = id.election_group_id
             self.assertEqual("%s.2018-05-03" % (election_type), election_id)
+            subtype_id = id.subtype_group_id
+            self.assertEqual("%s.c.2018-05-03" % (election_type), subtype_id)
             with self.assertRaises(ValueError):
                 id.organisation_group_id
             with self.assertRaises(ValueError):
                 id.ballot_id
             self.assertEqual([
                 "%s.2018-05-03" % (election_type),
+                "%s.c.2018-05-03" % (election_type),
             ], id.ids)
 
     def test_naw_sp_with_org(self):
@@ -65,12 +70,15 @@ class TestIdBuilder(TestCase):
                 .with_division('test-division')
             election_id = id.election_group_id
             self.assertEqual("%s.2018-05-03" % (election_type), election_id)
+            subtype_id = id.subtype_group_id
+            self.assertEqual("%s.r.2018-05-03" % (election_type), subtype_id)
             with self.assertRaises(ValueError):
                 id.organisation_group_id
             ballot_id = id.ballot_id
             self.assertEqual("%s.r.test-division.2018-05-03" % (election_type), ballot_id)
             self.assertEqual([
                 "%s.2018-05-03" % (election_type),
+                "%s.r.2018-05-03" % (election_type),
                 "%s.r.test-division.2018-05-03" % (election_type)
             ], id.ids)
 
@@ -92,6 +100,8 @@ class TestIdBuilder(TestCase):
             election_id = id.election_group_id
             self.assertEqual("%s.2018-05-03" % (election_type), election_id)
             with self.assertRaises(ValueError):
+                id.subtype_group_id
+            with self.assertRaises(ValueError):
                 id.organisation_group_id
             with self.assertRaises(ValueError):
                 id.ballot_id
@@ -103,6 +113,8 @@ class TestIdBuilder(TestCase):
                 .with_division('test-division')
             election_id = id.election_group_id
             self.assertEqual("%s.2018-05-03" % (election_type), election_id)
+            with self.assertRaises(ValueError):
+                id.subtype_group_id
             with self.assertRaises(ValueError):
                 id.organisation_group_id
             ballot_id = id.ballot_id
@@ -123,6 +135,8 @@ class TestIdBuilder(TestCase):
         with self.assertRaises(ValueError):
             id.election_group_id
         with self.assertRaises(ValueError):
+            id.subtype_group_id
+        with self.assertRaises(ValueError):
             id.organisation_group_id
         with self.assertRaises(ValueError):
             id.ballot_id
@@ -132,6 +146,8 @@ class TestIdBuilder(TestCase):
         id = IdBuilder('local', date(2018, 5, 3))
         election_id = id.election_group_id
         self.assertEqual("local.2018-05-03", election_id)
+        with self.assertRaises(ValueError):
+            id.subtype_group_id
         with self.assertRaises(ValueError):
             id.organisation_group_id
         with self.assertRaises(ValueError):
@@ -143,6 +159,8 @@ class TestIdBuilder(TestCase):
             .with_organisation('test-org')
         election_id = id.election_group_id
         self.assertEqual("local.2018-05-03", election_id)
+        with self.assertRaises(ValueError):
+            id.subtype_group_id
         organisation_id = id.organisation_group_id
         self.assertEqual("local.test-org.2018-05-03", organisation_id)
         with self.assertRaises(ValueError):
@@ -158,6 +176,8 @@ class TestIdBuilder(TestCase):
             .with_division('test-division')
         election_id = id.election_group_id
         self.assertEqual("local.2018-05-03", election_id)
+        with self.assertRaises(ValueError):
+            id.subtype_group_id
         organisation_id = id.organisation_group_id
         self.assertEqual("local.test-org.2018-05-03", organisation_id)
         ballot_id = id.ballot_id
@@ -186,6 +206,8 @@ class TestIdBuilder(TestCase):
                 .with_organisation('test-org')
             election_id = id.election_group_id
             self.assertEqual("%s.2018-05-03" % (election_type), election_id)
+            with self.assertRaises(ValueError):
+                id.subtype_group_id
             organisation_id = id.organisation_group_id
             ballot_id = id.ballot_id
             self.assertEqual("%s.test-org.2018-05-03" % (election_type), ballot_id)
@@ -200,6 +222,8 @@ class TestIdBuilder(TestCase):
             id = IdBuilder(election_type, date(2018, 5, 3))
             election_id = id.election_group_id
             self.assertEqual("%s.2018-05-03" % (election_type), election_id)
+            with self.assertRaises(ValueError):
+                id.subtype_group_id
             with self.assertRaises(ValueError):
                 id.organisation_group_id
             with self.assertRaises(ValueError):
@@ -217,6 +241,8 @@ class TestIdBuilder(TestCase):
         id = IdBuilder('gla', date(2018, 5, 3))
         election_id = id.election_group_id
         self.assertEqual('gla.2018-05-03', election_id)
+        with self.assertRaises(ValueError):
+            id.subtype_group_id
         with self.assertRaises(ValueError):
             id.organisation_group_id
         with self.assertRaises(ValueError):
@@ -245,6 +271,8 @@ class TestIdBuilder(TestCase):
             .with_subtype('a')
         election_id = id.election_group_id
         self.assertEqual("gla.2018-05-03", election_id)
+        subtype_id = id.subtype_group_id
+        self.assertEqual("gla.a.2018-05-03", subtype_id)
         with self.assertRaises(ValueError):
             id.organisation_group_id
         ballot_id = id.ballot_id
@@ -260,12 +288,15 @@ class TestIdBuilder(TestCase):
             .with_division('test-div')
         election_id = id.election_group_id
         self.assertEqual("gla.2018-05-03", election_id)
+        subtype_id = id.subtype_group_id
+        self.assertEqual("gla.c.2018-05-03", subtype_id)
         with self.assertRaises(ValueError):
             id.organisation_group_id
         ballot_id = id.ballot_id
         self.assertEqual("gla.c.test-div.2018-05-03", ballot_id)
         self.assertEqual([
             "gla.2018-05-03",
+            "gla.c.2018-05-03",
             "gla.c.test-div.2018-05-03"
         ], id.ids)
 


### PR DESCRIPTION
This PR adds in election subtypes as a proper heirarchy layer. In principle, this allows an election to have any combination of:

election type -> subtype -> organisation -> division

even though there is currently no election type we model that actually has all 4 of those things. These now operate in a strict hierarchy.

The upshot of this is we can:

* Deploy this
* Delete `naw.2018-02-06`, `naw.c.2018-02-06` and `naw.c.alyn-and-deeside.by.2018-02-06` from prod
* Re-create the IDs for `naw.c.alyn-and-deeside.by.2018-02-06` using this code (lets hold off on doing that for the moment though until we know if we also need to change the election system for `naw.c`)
* Modify the YNR import process to request elections from EE and do 2 passes over it:
  * One which makes a `Post` object for every election where the `group_type` is `NULL`
  * A second one which makes an `Election` object for the (first) parent election object of each `Post` + create a `PostExtraElection` join between them.
* That should then allow us to import everything cleanly (including this Welsh Assembly election) because all the meta-data we need should always be on the group id. We also shouldn't neeed to do anything else to the EE API to enable YNR to consume it.

We still need to account for mayors and PCCs.. not sure how best to do that. This seems like progress anyway.


refs https://github.com/DemocracyClub/yournextrepresentative/issues/320