### PR TITLE
Add Election ID Documentation

### DIFF
--- a/every_election/apps/elections/models.py
+++ b/every_election/apps/elections/models.py
@@ -15,9 +15,6 @@ from .managers import ElectionManager
 
 
 class ElectionType(models.Model):
-    """
-    As defined at https://democracyclub.org.uk/projects/election-ids/reference/
-    """
 
     name = models.CharField(blank=True, max_length=100)
     election_type = models.CharField(blank=True, max_length=100, unique=True)
@@ -29,9 +26,6 @@ class ElectionType(models.Model):
 
 
 class ElectionSubType(models.Model):
-    """
-    As defined at https://democracyclub.org.uk/projects/election-ids/reference/
-    """
 
     name = models.CharField(blank=True, max_length=100)
     election_type = models.ForeignKey('ElectionType', related_name="subtype")

--- a/every_election/apps/elections/templates/elections/election_types.html
+++ b/every_election/apps/elections/templates/elections/election_types.html
@@ -13,7 +13,7 @@
 
       <h5>Example Election ID:</h5>
       <p>
-          <code>{{ object.election_type }}{% if object.subtype.all %}.{{ object.subtype.all.0.election_subtype }}{% endif %}{% if object.organisation_set.all %}.{{ object.organisation_set.all.0.slug }}{% endif %}.2016-05-05</code>
+          <code>{{ object.election_type }}{% if object.subtype.all %}.{{ object.subtype.all.0.election_subtype }}{% endif %}{% if object.organisation_set.all.count > 1 %}.{{ object.organisation_set.all.0.slug }}{% endif %}.2016-05-05</code>
       </p>
 
       {% if object.subtype.all %}

--- a/every_election/apps/elections/templates/elections/reference_definition.html
+++ b/every_election/apps/elections/templates/elections/reference_definition.html
@@ -60,6 +60,12 @@
 
     <h4>Organisation</h4>
     <p>An administrative body which can hold an election.</p>
+
+    <p>When an election type only covers a single organisation the
+    organisation segment of the ID is excluded. This is to prevent
+    <code>parl.parl</code>, <code>naw.naw</code> and so on where the
+    organisation name and election type are the same.</p>
+
     <p>Organisation segments must use official names. Organisation names are
     sourced from
     <a href="https://registers.cloudapps.digital/">gov.uk registers</a>.

--- a/every_election/apps/elections/templates/elections/reference_definition.html
+++ b/every_election/apps/elections/templates/elections/reference_definition.html
@@ -60,11 +60,25 @@
 
     <h4>Organisation</h4>
     <p>An administrative body which can hold an election.</p>
+    <p>Organisation segments must use official names. Organisation names are
+    sourced from
+    <a href="https://registers.cloudapps.digital/">gov.uk registers</a>.
+    Short form versions of names should be used i.e:
+    <code>local.birmingham.2018-05-03</code> not
+    <code>local.birmingham-city-council.2017-05-04</code>.
+    </p>
 
     <h4>Division</h4>
     <p>A sub-part of an organisation that a candidate can be elected
     to represent. This could be a ward in the case of a local election
     or a constituency in the case of a parliamentary election.</p>
+
+    <p>Division segments must use names as they appear in legislation.
+    For boundaries that are already in use, the names of parliamentary
+    constituencies, district wards and county electoral divisions are
+    sourced from
+    <a href="https://www.ordnancesurvey.co.uk/business-and-government/products/boundary-line.html">OS Boundary Line</a>.
+    Names of new boundaries are extracted from Electoral Change Orders.</p>
 
     <h4>By-election</h4>
     <p>By-elections are indicated with the segment <code>by</code>.</p>
@@ -111,6 +125,13 @@
     <code>parl.2015-12-03</code>. The group id does not include the
     <code>by</code> segment, even if all of its childen are by-elections.
     </p>
+
+    <h3>Implementations</h3>
+    <p><a href="https://github.com/DemocracyClub/uk-election-ids">uk-election-ids</a>
+    - A python package with includes a builder object, slugging algorithm and
+    validation rules for creating identifiers that conform to this specification.
+    </p>
+
   </div>
 
 </section>

--- a/every_election/apps/elections/templates/elections/reference_definition.html
+++ b/every_election/apps/elections/templates/elections/reference_definition.html
@@ -1,0 +1,117 @@
+{% extends "base.html" %}
+
+
+{% block content %}
+<section class="columns large-6 large-centered">
+
+  <div class="card postcode_card">
+    <h2>Election Identifier Reference</h2>
+
+    <p>An election code starts with an election type string. It may optionally
+    contain descriptors for election subtype, organisation and division
+    The identifier is terminated with the date that the polls open
+    (in ISO 8601 format) for that particular election.
+    Each section is separated by a period character ('.').
+    Names are slugified with hyphens ('-') separating tokens.
+    An optional segment is used to indicate by-elections</p>
+
+    <p>All characters used are URL-friendly lowercase unreserved characters --
+    i.e. RFC3986 unreserved characters = ALPHA / DIGIT / "-" / "." / "_" / "~",
+    where ALPHA is [a-z] and DIGIT is [0-9].</p>
+
+    <p>Examples of this could be
+      <code>parl.2015-05-07</code> or
+      <code>local.ashfield.hucknall-north.by.2017-10-12</code>
+    </p>
+
+    <h3>Segments</h3>
+    <table>
+      <tr>
+        <td><strong>Election type</strong></td><td>Required, text</td>
+      </tr>
+      <tr>
+        <td><strong>Election subtype</strong></td><td>Optional, text</td>
+      </tr>
+      <tr>
+        <td><strong>Organisation</strong></td><td>Optional, text</td>
+      </tr>
+      <tr>
+        <td><strong>Division</strong></td><td>Optional, text</td>
+      </tr>
+      <tr>
+        <td><strong>By-election</strong></td><td>Optional, text</td>
+      </tr>
+      <tr>
+        <td><strong>Date polls open</strong></td>
+        <td>Required, (ISO 8601 format date)</td>
+      </tr>
+    </table>
+
+    <h4>Election type</h4>
+    <p>All election identifiers must include an election type.
+    This describes the type of elected office that will be held
+    by the winner(s) of this election.</p>
+
+    <h4>Election subtype</h4>
+    <p>Subtypes are used when an official body (Scottish Parliament,
+    National Assembly for Wales, Greater London Authority) elects members
+    by two different methods. In this case, elections are split into
+    sub-elections based on voting system.</p>
+
+    <h4>Organisation</h4>
+    <p>An administrative body which can hold an election.</p>
+
+    <h4>Division</h4>
+    <p>A sub-part of an organisation that a candidate can be elected
+    to represent. This could be a ward in the case of a local election
+    or a constituency in the case of a parliamentary election.</p>
+
+    <h4>By-election</h4>
+    <p>By-elections are indicated with the segment <code>by</code>.</p>
+
+    <h3>Identifier Types</h3>
+    <table>
+        <tr>
+          <th>Type</th>
+          <th>Subtype</th>
+          <th>Slug</th>
+          <th>Organisations</th>
+          <th>Divisions</th>
+        </tr>
+      {% for record in election_types %}
+        <tr>
+          <td>{{ record.name }}</td>
+          <td>{{ record.subtype.name }}</td>
+          <td>
+            <code>{{ record.slug }}{% if record.subtype.election_subtype %}.{{ record.subtype.election_subtype }}{% endif %}</code>
+          </td>
+          <td align="center">{% if record.can_have_orgs %}✔️{% else %}&nbsp;{% endif %}</td>
+          <td align="center">{% if record.can_have_divs %}✔️{% else %}&nbsp;{% endif %}</td>
+        </tr>
+      {% endfor %}
+    </table>
+
+    <h3>Hierarchy</h3>
+    <p>Election ids are hierarchical. The lowest level (or most detailed)
+    identifer for an election type is called the ballot id and describes
+    a single ballot paper. Each level above this is a group id.</p>
+
+    <p>For example, the ballot id<br />
+    <code>naw.c.aberavon.2016-05-05</code> is a child of the (subtype) group<br />
+    <code>naw.c.2016-05-05</code> which is in turn a child of the (election) group<br />
+    <code>naw.2016-05-05</code></p>
+
+    <p>Similarly, the ballot id<br />
+    <code>local.worcestershire.bewdley.2017-05-04</code> is a child of the (organisation) group<br />
+    <code>local.worcestershire.2017-05-04</code> which is in turn a child of the (election) group<br />
+    <code>local.2017-05-04</code></p>
+
+    <p>The <code>by</code> segment only applies to a ballot id, so<br />
+    <code>parl.oldham-west-and-royton.by.2015-12-03</code> is a child of <br />
+    <code>parl.2015-12-03</code>. The group id does not include the
+    <code>by</code> segment, even if all of its childen are by-elections.
+    </p>
+  </div>
+
+</section>
+{% endblock content %}

--- a/every_election/apps/elections/urls.py
+++ b/every_election/apps/elections/urls.py
@@ -6,6 +6,7 @@ from .views import (
     IDCreatorWizard,
     FORMS,
     CONDITION_DICT,
+    ReferenceDefinitionView,
     SingleElection,
 )
 from elections.views.sync import get_election_fixture
@@ -22,6 +23,9 @@ urlpatterns = [
     url(r'^election_types$',
         ElectionTypesView.as_view(),
         name='election_types_view'),
+    url(r'^reference_definition$',
+        ReferenceDefinitionView.as_view(),
+        name='reference_definition_view'),
 
     url(r'^elections$',
         AllElectionsView.as_view(),

--- a/every_election/apps/elections/views/general.py
+++ b/every_election/apps/elections/views/general.py
@@ -1,5 +1,7 @@
-from django.views.generic import ListView, DetailView
+from collections import OrderedDict
+from django.views.generic import ListView, DetailView, TemplateView
 
+from elections.constants import ELECTION_TYPES
 from elections.forms import NoticeOfElectionForm
 from elections.models import ElectionType, Election, Document
 
@@ -8,6 +10,46 @@ class ElectionTypesView(ListView):
     template_name = "elections/election_types.html"
     model = ElectionType
 
+
+class ReferenceDefinitionView(TemplateView):
+    template_name = "elections/reference_definition.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        # ELECTION_TYPES is optimised for fast
+        # lookups and not duplicating information.
+        # We need to transform ELECTION_TYPES into a data structure
+        # which is more optimised for generating HTML in a template:
+        election_types_table = []
+        for et_key, et_record in OrderedDict(sorted(ELECTION_TYPES.items())).items():
+
+            # for the moment leave 'ref' and 'eu' types out of the docs
+            # because our spec for these is incomplete
+            if et_key == 'eu' or et_key == 'ref':
+                continue
+
+            et_record['slug'] = et_key
+            et_record['subtype'] = None
+
+            if et_record['subtypes']:
+                # if we've got subtypes, duplicate the
+                # election type data for each subtype
+                for s_record in et_record['subtypes']:
+                    table_rec = et_record.copy()
+                    table_rec['subtype'] = s_record
+                    # subtype data takes precedence if it exists
+                    if 'can_have_orgs' in s_record:
+                        table_rec['can_have_orgs'] = s_record['can_have_orgs']
+                    if 'can_have_divs' in s_record:
+                        table_rec['can_have_divs'] = s_record['can_have_divs']
+                    election_types_table.append(table_rec)
+            else:
+                # otherwise just shove it in the list
+                election_types_table.append(et_record)
+
+        context['election_types'] = election_types_table
+        return context
 
 class AllElectionsView(ListView):
     template_name = "elections/elections.html"

--- a/every_election/templates/base.html
+++ b/every_election/templates/base.html
@@ -25,6 +25,7 @@
                 <li><a href="{% url "home"%}">Home</a></li>
                 <li><a href="{% url "organisations_view"%}">Organisations</a></li>
                 <li><a href="{% url "election_types_view"%}">Election Types</a></li>
+                <li><a href="{% url "reference_definition_view"%}">Reference Definition</a></li>
                 <li><a href="{% url "elections_view"%}">Elections</a></li>
                 <li><a href="{% url "id_creator"%}">ID Creator</a></li>
             </ul>


### PR DESCRIPTION
Notes:
* This is a useful starting point. It probably needs refinement, but it is a step up from nothing.
* I've ~fixed 'Election Types'~ made 'Election Types' less broken in this PR, but I'm not sure if it is necessarily a useful thing to have alongside this as a lot of the content is duplicated. Maybe it should just be replaced by this?
* I'm struggling to properly articulate when the organisation layer is relevant. An organisation is 'an administrative body which can hold an election', but sometimes that organisation is implicit in the election type and sometimes it needs to be explicit in the identifier but I can't quite explain the rule for when each of those scenarios is true.
* ~I have deliberately not talked about how you know what area names to use because this is still a bit.. fuzzy.~
* ~I've also left out a description of the slugging algortihm. I'm not quite sure how to address it.~
* I need to submit another PR to https://github.com/DemocracyClub/Website/ removing https://github.com/DemocracyClub/Website/blob/master/democracy_club/templates/election-ids/reference.html and linking to this.

Closes #48