### PR TITLE
improve naming for group ids

### DIFF
--- a/every_election/apps/api/tests/test_api_election_endpoint.py
+++ b/every_election/apps/api/tests/test_api_election_endpoint.py
@@ -128,7 +128,7 @@ class TestElectionAPIQueries(APITestCase):
                         "territory_code": "ENG"
                     },
                     "election_type": {
-                        "name": "Local elections",
+                        "name": "Local Elections",
                         "election_type": "local"
                     },
                     "explanation": null,

--- a/every_election/apps/api/tests/test_api_election_endpoint.py
+++ b/every_election/apps/api/tests/test_api_election_endpoint.py
@@ -128,7 +128,7 @@ class TestElectionAPIQueries(APITestCase):
                         "territory_code": "ENG"
                     },
                     "election_type": {
-                        "name": "Local Elections",
+                        "name": "Local elections",
                         "election_type": "local"
                     },
                     "explanation": null,

--- a/every_election/apps/elections/constants.py
+++ b/every_election/apps/elections/constants.py
@@ -3,7 +3,7 @@ from uk_election_ids.datapackage import ELECTION_TYPES
 
 # These types exist in EE but don't have defined behaviour in the IdBuilder
 ELECTION_TYPES['eu'] = {
-    'name': "European parliament (UK) Elections",
+    'name': "European Parliament (UK) elections",
     'subtypes': [],
     'default_voting_system': 'PR-CL',
 }

--- a/every_election/apps/elections/constants.py
+++ b/every_election/apps/elections/constants.py
@@ -3,7 +3,7 @@ from uk_election_ids.datapackage import ELECTION_TYPES
 
 # These types exist in EE but don't have defined behaviour in the IdBuilder
 ELECTION_TYPES['eu'] = {
-    'name': "European parliament (UK)",
+    'name': "European parliament (UK) Elections",
     'subtypes': [],
     'default_voting_system': 'PR-CL',
 }

--- a/every_election/apps/elections/tests/base_tests.py
+++ b/every_election/apps/elections/tests/base_tests.py
@@ -33,7 +33,7 @@ class BaseElectionCreatorMixIn():
             gss="X00000001",
             slug="test",
             territory_code="ENG",
-            election_name="Test Council Local Elections",
+            election_name="Test Council local elections",
         )
 
         self.elected_role1 = ElectedRole.objects.create(

--- a/every_election/apps/elections/tests/test_create_ids.py
+++ b/every_election/apps/elections/tests/test_create_ids.py
@@ -10,13 +10,17 @@ from .base_tests import BaseElectionCreatorMixIn
 
 class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
 
-    def run_test_with_data(self, all_data, expected_ids, **kwargs):
+    def run_test_with_data(self, all_data, expected_ids, expected_titles, **kwargs):
         self.create_ids(all_data, **kwargs)
         assert Election.objects.count() == len(expected_ids)
 
         # ensure the records created match the expected ids
         for expected_id in expected_ids:
             assert Election.objects.filter(election_id=expected_id).exists()
+
+        # ensure the records created match the expected titles
+        for expected_title in expected_titles:
+            assert Election.objects.filter(election_title=expected_title).exists()
 
         # ensure group relationships have been saved correctly
         for election in Election.objects.all():
@@ -26,7 +30,8 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
     def test_group_id(self):
         self.run_test_with_data(
             self.base_data,
-            ['local.'+self.date_str, ]
+            ['local.'+self.date_str, ],
+            ['Local Elections',]
         )
 
     def test_creates_div_data_ids(self):
@@ -38,10 +43,16 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             'local.test.'+self.date_str,
             'local.test.test-div.'+self.date_str,
         ]
+        expected_titles = [
+            'Local Elections',
+            'Test Council Local Elections',
+            'Test Council Local Elections Test Div 1',
+        ]
 
         self.run_test_with_data(
             all_data,
-            expected_ids
+            expected_ids,
+            expected_titles
         )
 
     def test_creates_div_data_ids_two_divs(self):
@@ -57,10 +68,17 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             'local.test.test-div.'+self.date_str,
             'local.test.test-div-2.'+self.date_str,
         ]
+        expected_titles = [
+            'Local Elections',
+            'Test Council Local Elections',
+            'Test Council Local Elections Test Div 1',
+            'Test Council Local Elections Test Div 2',
+        ]
 
         self.run_test_with_data(
             all_data,
-            expected_ids
+            expected_ids,
+            expected_titles
         )
 
     def test_creates_ids_two_orgs(self):
@@ -98,10 +116,18 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             'local.test.test-div.'+self.date_str,
             'local.test2.test-div-3.'+self.date_str,
         ]
+        expected_titles = [
+            'Local Elections',
+            'Test Council Local Elections',
+            'Test Council 2 Local Elections',
+            'Test Council Local Elections Test Div 1',
+            'Test Council 2 Local Elections Test Div 3',
+        ]
 
         self.run_test_with_data(
             all_data,
-            expected_ids
+            expected_ids,
+            expected_titles
         )
 
     def test_creates_div_data_ids_blank_divs(self):
@@ -116,10 +142,16 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             'local.test.'+self.date_str,
             'local.test.test-div.'+self.date_str,
         ]
+        expected_titles = [
+            'Local Elections',
+            'Test Council Local Elections',
+            'Test Council Local Elections Test Div 1',
+        ]
 
         self.run_test_with_data(
             all_data,
-            expected_ids
+            expected_ids,
+            expected_titles
         )
 
     def test_creates_by_election(self):
@@ -135,10 +167,17 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             'local.test.test-div.by.'+self.date_str,
             'local.test.test-div-2.by.'+self.date_str,
         ]
+        expected_titles = [
+            'Local Elections',
+            'Test Council Local Elections',
+            'Test Council Local Elections Test Div 1 by-election',
+            'Test Council Local Elections Test Div 2 by-election',
+        ]
 
         self.run_test_with_data(
             all_data,
-            expected_ids
+            expected_ids,
+            expected_titles
         )
 
         for election in Election.objects.filter(group_type=None):
@@ -175,10 +214,15 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             'mayor.'+self.date_str,
             'mayor.test-ca.'+self.date_str,
         ]
+        expected_titles = [
+            'Mayoral Elections',
+            'Test Council Mayoral Elections',
+        ]
 
         self.run_test_with_data(
             all_data,
-            expected_ids
+            expected_ids,
+            expected_titles
         )
 
     def test_creates_parl_id(self):
@@ -211,10 +255,14 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
         expected_ids = [
             'parl.'+self.date_str,
         ]
+        expected_titles = [
+            'UK Parliament Elections',
+        ]
 
         self.run_test_with_data(
             all_data,
-            expected_ids
+            expected_ids,
+            expected_titles
         )
 
     def test_creates_naw_id(self):
@@ -225,7 +273,7 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             gss="W20000001",
             slug="naw",
             territory_code="WLS",
-            election_name="Welsh Assembly",
+            election_name="Welsh Assembly Elections",
         )
         naw_election_type = ElectionType.objects.get(
             election_type='naw',
@@ -272,10 +320,17 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             'naw.c.test-div-3.'+self.date_str,  # no 'by' suffix
             'naw.c.test-div-4.by.'+self.date_str,  # 'by' suffix
         ]
+        expected_titles = [
+            'Welsh Assembly Elections',
+            'Welsh Assembly Elections (Constituencies)',
+            'Test Div 3 (Constituencies)',
+            'Test Div 4 (Constituencies) by-election',
+        ]
 
         self.run_test_with_data(
             all_data,
             expected_ids,
+            expected_titles,
             subtypes=[naw_election_sub_type, ]
         )
 
@@ -297,10 +352,17 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             'local.test.test-div.'+self.date_str,
             'local.test.test-div-2.'+self.date_str,
         ]
+        expected_titles = [
+            'Local Elections',
+            'Test Council Local Elections',
+            'Test Council Local Elections Test Div 1',
+            'Test Council Local Elections Test Div 2',
+        ]
 
         self.run_test_with_data(
             all_data,
-            expected_ids
+            expected_ids,
+            expected_titles
         )
 
         for election in Election.objects.all():
@@ -333,10 +395,17 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             'local.test.test-div.'+self.date_str,
             'local.test.test-div-2.'+self.date_str,
         ]
+        expected_titles = [
+            'Local Elections',
+            'Test Council Local Elections',
+            'Test Council Local Elections Test Div 1',
+            'Test Council Local Elections Test Div 2',
+        ]
 
         self.run_test_with_data(
             all_data,
-            expected_ids
+            expected_ids,
+            expected_titles
         )
 
         for election in Election.objects.all():

--- a/every_election/apps/elections/tests/test_create_ids.py
+++ b/every_election/apps/elections/tests/test_create_ids.py
@@ -31,7 +31,7 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
         self.run_test_with_data(
             self.base_data,
             ['local.'+self.date_str, ],
-            ['Local Elections',]
+            ['Local elections',]
         )
 
     def test_creates_div_data_ids(self):
@@ -44,9 +44,9 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             'local.test.test-div.'+self.date_str,
         ]
         expected_titles = [
-            'Local Elections',
-            'Test Council Local Elections',
-            'Test Council Local Elections Test Div 1',
+            'Local elections',
+            'Test Council local elections',
+            'Test Council local elections Test Div 1',
         ]
 
         self.run_test_with_data(
@@ -69,10 +69,10 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             'local.test.test-div-2.'+self.date_str,
         ]
         expected_titles = [
-            'Local Elections',
-            'Test Council Local Elections',
-            'Test Council Local Elections Test Div 1',
-            'Test Council Local Elections Test Div 2',
+            'Local elections',
+            'Test Council local elections',
+            'Test Council local elections Test Div 1',
+            'Test Council local elections Test Div 2',
         ]
 
         self.run_test_with_data(
@@ -89,7 +89,7 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             gss="X00000002",
             slug="test2",
             territory_code="ENG",
-            election_name="Test Council 2 Local Elections",
+            election_name="Test Council 2 local elections",
         )
         ElectedRole.objects.create(
             election_type=self.election_type1,
@@ -117,11 +117,11 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             'local.test2.test-div-3.'+self.date_str,
         ]
         expected_titles = [
-            'Local Elections',
-            'Test Council Local Elections',
-            'Test Council 2 Local Elections',
-            'Test Council Local Elections Test Div 1',
-            'Test Council 2 Local Elections Test Div 3',
+            'Local elections',
+            'Test Council local elections',
+            'Test Council 2 local elections',
+            'Test Council local elections Test Div 1',
+            'Test Council 2 local elections Test Div 3',
         ]
 
         self.run_test_with_data(
@@ -143,9 +143,9 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             'local.test.test-div.'+self.date_str,
         ]
         expected_titles = [
-            'Local Elections',
-            'Test Council Local Elections',
-            'Test Council Local Elections Test Div 1',
+            'Local elections',
+            'Test Council local elections',
+            'Test Council local elections Test Div 1',
         ]
 
         self.run_test_with_data(
@@ -168,10 +168,10 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             'local.test.test-div-2.by.'+self.date_str,
         ]
         expected_titles = [
-            'Local Elections',
-            'Test Council Local Elections',
-            'Test Council Local Elections Test Div 1 by-election',
-            'Test Council Local Elections Test Div 2 by-election',
+            'Local elections',
+            'Test Council local elections',
+            'Test Council local elections Test Div 1 by-election',
+            'Test Council local elections Test Div 2 by-election',
         ]
 
         self.run_test_with_data(
@@ -191,7 +191,7 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             gss="X10000001",
             slug="test-ca",
             territory_code="ENG",
-            election_name="Test Council Mayoral Elections",
+            election_name="Test Council Mayoral elections",
         )
         mayor_election_type = ElectionType.objects.get(
             election_type='mayor',
@@ -215,8 +215,8 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             'mayor.test-ca.'+self.date_str,
         ]
         expected_titles = [
-            'Mayoral Elections',
-            'Test Council Mayoral Elections',
+            'Mayoral elections',
+            'Test Council Mayoral elections',
         ]
 
         self.run_test_with_data(
@@ -256,7 +256,7 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             'parl.'+self.date_str,
         ]
         expected_titles = [
-            'UK Parliament Elections',
+            'UK Parliament elections',
         ]
 
         self.run_test_with_data(
@@ -273,7 +273,7 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             gss="W20000001",
             slug="naw",
             territory_code="WLS",
-            election_name="Welsh Assembly Elections",
+            election_name="National Assembly for Wales elections",
         )
         naw_election_type = ElectionType.objects.get(
             election_type='naw',
@@ -321,8 +321,8 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             'naw.c.test-div-4.by.'+self.date_str,  # 'by' suffix
         ]
         expected_titles = [
-            'Welsh Assembly Elections',
-            'Welsh Assembly Elections (Constituencies)',
+            'National Assembly for Wales elections',
+            'National Assembly for Wales elections (Constituencies)',
             'Test Div 3 (Constituencies)',
             'Test Div 4 (Constituencies) by-election',
         ]
@@ -353,10 +353,10 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             'local.test.test-div-2.'+self.date_str,
         ]
         expected_titles = [
-            'Local Elections',
-            'Test Council Local Elections',
-            'Test Council Local Elections Test Div 1',
-            'Test Council Local Elections Test Div 2',
+            'Local elections',
+            'Test Council local elections',
+            'Test Council local elections Test Div 1',
+            'Test Council local elections Test Div 2',
         ]
 
         self.run_test_with_data(
@@ -396,10 +396,10 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             'local.test.test-div-2.'+self.date_str,
         ]
         expected_titles = [
-            'Local Elections',
-            'Test Council Local Elections',
-            'Test Council Local Elections Test Div 1',
-            'Test Council Local Elections Test Div 2',
+            'Local elections',
+            'Test Council local elections',
+            'Test Council local elections Test Div 1',
+            'Test Council local elections Test Div 2',
         ]
 
         self.run_test_with_data(

--- a/every_election/apps/elections/utils.py
+++ b/every_election/apps/elections/utils.py
@@ -135,7 +135,15 @@ class ElectionBuilder:
     def __repr__(self):
         return self.id.__repr__()
 
-    def to_title(self):
+    def to_title(self, id_type):
+        if id_type == 'election':
+            return self.election_type.name
+        if id_type == 'subtype':
+            return "{election} ({subtype})".format(
+                election=self.election_type.name,
+                subtype=self.subtype.name
+            )
+
         parts = []
         if self._use_org and self.organisation:
             parts.append(self.organisation.election_name)
@@ -166,7 +174,6 @@ class ElectionBuilder:
             return Election(**merge_dicts(record, {
                 'poll_open_date': self.date,
                 'election_type': self.election_type,
-                'election_title': self.to_title(),
                 'election_subtype': self.subtype,
                 'organisation': self.organisation,
                 'division': self.division,
@@ -177,6 +184,7 @@ class ElectionBuilder:
     def build_election_group(self):
         return self._build({
             'election_id': self.id.election_group_id,
+            'election_title': self.to_title('election'),
             'group': None,
             'group_type': 'election',
             'notice': None,
@@ -187,6 +195,7 @@ class ElectionBuilder:
     def build_subtype_group(self, group):
         return self._build({
             'election_id': self.id.subtype_group_id,
+            'election_title': self.to_title('subtype'),
             'group': group,
             'group_type': 'subtype',
             'notice': None,
@@ -197,6 +206,7 @@ class ElectionBuilder:
     def build_organisation_group(self, group):
         return self._build({
             'election_id': self.id.organisation_group_id,
+            'election_title': self.to_title('organisation'),
             'group': group,
             'group_type': 'organisation',
             'notice': None,
@@ -207,6 +217,7 @@ class ElectionBuilder:
     def build_ballot(self, group):
         return self._build({
             'election_id': self.id.ballot_id,
+            'election_title': self.to_title('ballot'),
             'group': group,
             'group_type': None,
             'notice': self.notice,

--- a/every_election/apps/uk_election_ids/datapackage.py
+++ b/every_election/apps/uk_election_ids/datapackage.py
@@ -1,20 +1,20 @@
 ELECTION_TYPES = {
     'parl': {
-        'name': "UK Parliament",
+        'name': "UK Parliament Elections",
         'subtypes': [],
         'default_voting_system': 'FPTP',
         'can_have_orgs': False,
         'can_have_divs': True,
     },
     'nia': {
-        'name': "Northern Ireland assembly",
+        'name': "Northern Ireland Assembly Elections",
         'subtypes': [],
         'default_voting_system': 'STV',
         'can_have_orgs': False,
         'can_have_divs': True,
     },
     'naw': {
-        'name': "Welsh assembly",
+        'name': "Welsh Assembly Elections",
         'subtypes': [
             {'name': 'Constituencies', 'election_subtype': 'c'},
             {'name': 'Regions', 'election_subtype': 'r'},
@@ -24,7 +24,7 @@ ELECTION_TYPES = {
         'can_have_divs': True,
     },
     'sp': {
-        'name': "Scottish parliament",
+        'name': "Scottish Parliament Elections",
         'subtypes': [
             {'name': 'Constituencies', 'election_subtype': 'c'},
             {'name': 'Regions', 'election_subtype': 'r'},
@@ -34,7 +34,7 @@ ELECTION_TYPES = {
         'can_have_divs': True,
     },
     'gla': {
-        'name': "Greater London assembly",
+        'name': "Greater London Assembly Elections",
         'subtypes': [
             {
                 'name': 'Constituencies',
@@ -51,21 +51,21 @@ ELECTION_TYPES = {
         'default_voting_system': 'AMS',
     },
     'local': {
-        'name': "Local elections",
+        'name': "Local Elections",
         'subtypes': [],
         'default_voting_system': 'FPTP',
         'can_have_orgs': True,
         'can_have_divs': True,
     },
     'pcc': {
-        'name': "Police and crime commissioner",
+        'name': "Police and Crime Commissioner Elections",
         'subtypes': [],
         'default_voting_system': 'sv',
         'can_have_orgs': True,
         'can_have_divs': False,
     },
     'mayor': {
-        'name': "Directly elected Mayor",
+        'name': "Mayoral Elections",
         'subtypes': [],
         'default_voting_system': 'sv',
         'can_have_orgs': True,

--- a/every_election/apps/uk_election_ids/datapackage.py
+++ b/every_election/apps/uk_election_ids/datapackage.py
@@ -1,20 +1,20 @@
 ELECTION_TYPES = {
     'parl': {
-        'name': "UK Parliament Elections",
+        'name': "UK Parliament elections",
         'subtypes': [],
         'default_voting_system': 'FPTP',
         'can_have_orgs': False,
         'can_have_divs': True,
     },
     'nia': {
-        'name': "Northern Ireland Assembly Elections",
+        'name': "Northern Ireland Assembly elections",
         'subtypes': [],
         'default_voting_system': 'STV',
         'can_have_orgs': False,
         'can_have_divs': True,
     },
     'naw': {
-        'name': "Welsh Assembly Elections",
+        'name': "National Assembly for Wales elections",
         'subtypes': [
             {'name': 'Constituencies', 'election_subtype': 'c'},
             {'name': 'Regions', 'election_subtype': 'r'},
@@ -24,7 +24,7 @@ ELECTION_TYPES = {
         'can_have_divs': True,
     },
     'sp': {
-        'name': "Scottish Parliament Elections",
+        'name': "Scottish Parliament elections",
         'subtypes': [
             {'name': 'Constituencies', 'election_subtype': 'c'},
             {'name': 'Regions', 'election_subtype': 'r'},
@@ -34,7 +34,7 @@ ELECTION_TYPES = {
         'can_have_divs': True,
     },
     'gla': {
-        'name': "Greater London Assembly Elections",
+        'name': "Greater London Assembly elections",
         'subtypes': [
             {
                 'name': 'Constituencies',
@@ -51,21 +51,21 @@ ELECTION_TYPES = {
         'default_voting_system': 'AMS',
     },
     'local': {
-        'name': "Local Elections",
+        'name': "Local elections",
         'subtypes': [],
         'default_voting_system': 'FPTP',
         'can_have_orgs': True,
         'can_have_divs': True,
     },
     'pcc': {
-        'name': "Police and Crime Commissioner Elections",
+        'name': "Police and Crime Commissioner elections",
         'subtypes': [],
         'default_voting_system': 'sv',
         'can_have_orgs': True,
         'can_have_divs': False,
     },
     'mayor': {
-        'name': "Mayoral Elections",
+        'name': "Mayoral elections",
         'subtypes': [],
         'default_voting_system': 'sv',
         'can_have_orgs': True,


### PR DESCRIPTION
Closes #155 

To deploy this we'll need to re-run `python manage.py add_election_types` to update the titles on the election types table.