### PR TITLE
upgrade to Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ script:
 after_success:
   - coveralls
 before_cache:
-    - rm -f .tox/py34-django110/log/*.log
-    - rm -f .tox/py35-django110/log/*.log
-    - rm -f .tox/py36-django110/log/*.log
+    - rm -f .tox/py34-django111/log/*.log
+    - rm -f .tox/py35-django111/log/*.log
+    - rm -f .tox/py36-django111/log/*.log
     - rm -f .cache/pip/log/*.log
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: python
 python:
   - '3.6'
   - '3.5'
-  - '3.4'
 addons:
   postgresql: '9.3'
   apt:
@@ -26,7 +25,6 @@ script:
 after_success:
   - coveralls
 before_cache:
-    - rm -f .tox/py34-django111/log/*.log
     - rm -f .tox/py35-django111/log/*.log
     - rm -f .tox/py36-django111/log/*.log
     - rm -f .cache/pip/log/*.log

--- a/every_election/apps/election_snooper/models.py
+++ b/every_election/apps/election_snooper/models.py
@@ -1,7 +1,7 @@
 import datetime
 
 from django.db import models
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from model_utils.models import StatusModel
 from model_utils import Choices

--- a/every_election/apps/election_snooper/views.py
+++ b/every_election/apps/election_snooper/views.py
@@ -2,7 +2,7 @@ import urllib
 from django.views.generic import TemplateView
 from django.http import HttpResponseRedirect
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from election_snooper.models import SnoopedElection
 from election_snooper.forms import ReviewElectionForm

--- a/every_election/apps/elections/models.py
+++ b/every_election/apps/elections/models.py
@@ -5,7 +5,7 @@ from datetime import date, timedelta
 
 from django.db import models, transaction
 from django.core.files import File
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.core.exceptions import ObjectDoesNotExist
 from django_markdown.models import MarkdownField
 

--- a/every_election/apps/organisations/models.py
+++ b/every_election/apps/organisations/models.py
@@ -1,5 +1,5 @@
 from django.contrib.gis.db import models
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 
 class Organisation(models.Model):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,8 +16,8 @@ uk-election-ids==0.1.0
 django-formtools==2.0
 django-filter
 django-markdown-app==0.9.3.1
-djangorestframework==3.5.4
-djangorestframework-gis==0.11
+djangorestframework==3.7.7
+djangorestframework-gis==0.12
 django-storages
 django-extensions==1.7.7
 glob2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@
 # After the first "pip install -r", just run "pip freeze" and add the version
 # to each package in each requirements/*.txt.
 
-Django>=1.10,<1.11
+Django>=1.11,<2.0
 six
 
 django-model-utils==2.6.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ django-model-utils==2.6.1
 psycopg2
 
 git+https://github.com/mysociety/django-pipeline-csscompressor
-git+git://github.com/DemocracyClub/dc_base_theme.git@72f902ea6fbf1c3891ac279351d7d42a6f7eb216
+git+git://github.com/DemocracyClub/dc_base_theme.git@2ffca23e03549231eaaa23f0994c5b27e898fe43
 git+https://github.com/DemocracyClub/dc_signup_form.git@1.0.0
 uk-election-ids==0.1.0
 django-formtools==2.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
 # Ensure you add to .travis.yml if you add here
 # envlist = {py27,py34}-django{18,19,110}
-envlist = {py34,py35,py36}-django111
+envlist = {py35,py36}-django111
 skipsdist = True
 
 [tox:travis]
-3.4 = py34
 3.5 = py35
 3.6 = py36
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # Ensure you add to .travis.yml if you add here
 # envlist = {py27,py34}-django{18,19,110}
-envlist = {py34,py35,py36}-django110
+envlist = {py34,py35,py36}-django111
 skipsdist = True
 
 [tox:travis]


### PR DESCRIPTION
This is not ready for merge yet - need to get https://github.com/DemocracyClub/dc_base_theme/pull/24 in first so I can upgrade the theme dependency - should be good to go after that.

Closes #149

Side issue while I am looking at dependencies: given most of our dependencies on this project are un-pinned we're occasionally unwittingly upgrading them, so I think I'm going to work through them, pin a load of stuff and enable pyupbot on this repo but I will deal with that as a different piece of work.