### PR TITLE
Drop invalid host header emails

### DIFF
--- a/every_election/settings/base.py
+++ b/every_election/settings/base.py
@@ -49,6 +49,38 @@ PROJECT_APPS = [
 
 INSTALLED_APPS += PROJECT_APPS
 
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse'
+        }
+    },
+    'handlers': {
+        'mail_admins': {
+            'level': 'ERROR',
+            'filters': ['require_debug_false'],
+            'class': 'django.utils.log.AdminEmailHandler'
+        },
+        'null': {
+            'class': 'logging.NullHandler',
+        },
+    },
+    'loggers': {
+        # Silence DisallowedHost exception by setting null error handler
+        'django.security.DisallowedHost': {
+            'handlers': ['null'],
+            'propagate': False,
+        },
+        'django.request': {
+            'handlers': ['mail_admins'],
+            'level': 'ERROR',
+            'propagate': True,
+        },
+    }
+}
+
 MIDDLEWARE_CLASSES = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',


### PR DESCRIPTION
Closes #193 

Seeing as it is a straight copy and paste job to do this, I don't see any reason to introduce a possible [host header attack](https://docs.djangoproject.com/en/1.11/topics/security/#host-headers-virtual-hosting).