### PR TITLE
Update dc_signup_form to 2.0.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,4 +19,4 @@ uk-election-ids==0.1.0
 
 git+https://github.com/mysociety/django-pipeline-csscompressor
 git+git://github.com/DemocracyClub/dc_base_theme.git@2ffca23e03549231eaaa23f0994c5b27e898fe43
-git+https://github.com/DemocracyClub/dc_signup_form.git@1.0.0
+git+https://github.com/DemocracyClub/dc_signup_form.git@2.0.0


### PR DESCRIPTION
2.0.0 drops support for Django < 1.10, Adds support for Django 2.0 and drops support for Postgres < 9.4

This dependency can be safely upgraded on the 'client' installs independently of upgrading the main website ( https://github.com/DemocracyClub/Website/pull/102 ) because the API does not change in 2.0.0. All the BC-breaks are just platform compatibility