### PR TITLE
Import posts per ward

### DIFF
--- a/every_election/apps/core/mixins.py
+++ b/every_election/apps/core/mixins.py
@@ -1,0 +1,72 @@
+import csv
+import re
+
+import requests
+from django.conf import settings
+
+from storage.s3wrapper import S3Wrapper
+
+
+class ReadFromCSVMixin(object):
+    """
+    A generic mixin for for a reading from a CSV file in a Django
+    management command.
+
+    The CSV file can be a local file, a URL or on an S3 bucket.
+
+    `self.S3_BUCKET_NAME` needs to be set when using S3.
+    """
+    ENCODING = 'utf-8'
+    DELIMITER = ','
+    S3_BUCKET_NAME = settings.LGBCE_BUCKET
+
+    def add_arguments(self, parser):
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument(
+            '-f',
+            '--file',
+            action='store',
+            help='Path to import e.g: /foo/bar/baz.csv',
+        )
+        group.add_argument(
+            '-u',
+            '--url',
+            action='store',
+            help='URL to import e.g: http://foo.bar/baz.csv',
+        )
+        group.add_argument(
+            '-s',
+            '--s3',
+            action='store',
+            help='S3 key to import e.g: foo/bar/baz.csv'
+        )
+
+    def read_local_csv(self, filename):
+        f = open(filename, 'rt', encoding=self.ENCODING)
+        reader = csv.DictReader(f, delimiter=self.DELIMITER)
+        return list(reader)
+
+    def read_csv_from_url(self, url):
+        r = requests.get(url)
+
+        # if CSV came from google docs
+        # manually set the encoding
+        gdocs_pattern = r'(.)+docs\.google(.)+\/ccc(.)+'
+        if re.match(gdocs_pattern, url):
+            r.encoding = self.ENCODING
+
+        csv_reader = csv.DictReader(r.text.splitlines())
+        return list(csv_reader)
+
+    def read_csv_from_s3(self, filepath):
+        s3 = S3Wrapper(self.S3_BUCKET_NAME)
+        f = s3.get_file(filepath)
+        return self.read_local_csv(f.name)
+
+    def load_csv_data(self, options):
+        if options['file']:
+            return self.read_local_csv(options['file'])
+        if options['url']:
+            return self.read_csv_from_url(options['url'])
+        if options['s3']:
+            return self.read_csv_from_s3(options['s3'])

--- a/every_election/apps/elections/management/commands/attach_posts_per_election_from_csv.py
+++ b/every_election/apps/elections/management/commands/attach_posts_per_election_from_csv.py
@@ -1,0 +1,122 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from core.mixins import ReadFromCSVMixin
+from elections.models import Election
+
+
+class Command(ReadFromCSVMixin, BaseCommand):
+
+    SEATS_CONTESTED_FIELD = 'posts up'
+
+    help = """
+    Given a CSV file, path or url import the number of contested seats for that
+    election.
+
+    Expected CSV format is, e.g:
+
+    ORG Name,ORG GSS,REG,geography_curie,ward name,seats_total,has_election,posts up,created,id,problem/note
+    Eastleigh,E07000086,EAT,EAT:bishopstoke,Bishopstoke,3,yes,3,yes,local.eastleigh.bishopstoke.2018-05-03,
+    Eastleigh,E07000086,EAT,EAT:botley,Botley,2,yes,2,yes,local.eastleigh.botley.2018-05-03,
+
+
+    Optionally update the seats total for that election if
+    --replace-seats-total specified.
+    """  # noqa
+
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
+            '--replace-seats-total',
+            action='store_true',
+            help="Replace seats total in the database with the value in the CSV file"  # noqa
+        )
+        parser.add_argument(
+            '--skip-unknown',
+            action='store_true',
+            help="Skip elections with unknown seats total"
+        )
+
+    def get_seats_total(self, election, line, trust_csv=False):
+        csv_seats_total = None
+        db_seats_total = None
+        seats_total = None
+
+        # See if we already have the seats_total
+        if election.division.seats_total:
+            db_seats_total = election.division.seats_total
+
+        if line['seats_total']:
+            csv_seats_total = int(line['seats_total'] or None)
+
+        if db_seats_total:
+            # Warn if the CSV has a different seats total
+            if csv_seats_total != db_seats_total:
+                self.stdout.write(
+                    "Seats total mismatch for {} ({} vs {})".format(
+                        election.election_id,
+                        csv_seats_total,
+                        db_seats_total,
+                    ))
+            seats_total = db_seats_total
+        else:
+            if trust_csv and csv_seats_total and csv_seats_total > 0:
+                self.stdout.write("Taking seats total from CSV for {}".format(
+                    election.election_id,
+                ))
+                seats_total = csv_seats_total
+
+        return seats_total
+
+    def get_seats_contested(self, line):
+        try:
+            seats_contested = int(line[self.SEATS_CONTESTED_FIELD] or 0)
+        except ValueError:
+            raise ValueError(
+                "Seats contested must be int. Found {}".format(
+                    type(line[self.SEATS_CONTESTED_FIELD])
+                ))
+        return seats_contested
+
+    @transaction.atomic
+    def save_all(self, updated_elections):
+        for election in updated_elections:
+            election.save()
+
+    def handle(self, *args, **options):
+        data = self.load_csv_data(options)
+        trust_csv = options['replace_seats_total']
+        updated_elections = []
+        for line in data:
+            if line['created'] == "yes":
+
+                election = Election.objects.get(
+                    election_id=line['id']
+                )
+                seats_contested = self.get_seats_contested(line)
+
+                seats_total = self.get_seats_total(
+                    election,
+                    line,
+                    trust_csv=trust_csv,
+                )
+                if seats_total is None:
+                    message = "Seats total not known for {}".format(
+                            election.election_id
+                        )
+                    if options['skip_unknown']:
+                        self.stdout.write(message)
+                    else:
+                        raise ValueError(message)
+
+                if seats_total and not seats_total >= seats_contested:
+                    raise ValueError(
+                        "seats total less than seats_contested for {}".format(
+                            election.election_id))
+
+                election.seats_contested = seats_contested
+                if seats_total and trust_csv:
+                    election.seats_total = seats_total
+                updated_elections.append(election)
+
+        self.save_all(updated_elections)

--- a/every_election/apps/elections/tests/factories.py
+++ b/every_election/apps/elections/tests/factories.py
@@ -30,6 +30,7 @@ class ElectedRoleFactory(factory.django.DjangoModelFactory):
 class ElectionFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Election
+        django_get_or_create = ('election_id', )
 
     election_id = factory.Sequence(
         lambda n: 'local.place-name-%d.2017-03-23' % n)
@@ -45,7 +46,7 @@ class ElectionFactory(factory.django.DjangoModelFactory):
     group = factory.SubFactory(
         'elections.tests.factories.ElectionFactory',
         election_id="local.2017-03-23",
-        group=None)
+        group=None, group_type="election")
     group_type = None
 
 

--- a/every_election/apps/elections/tests/test_attach_posts_command.py
+++ b/every_election/apps/elections/tests/test_attach_posts_command.py
@@ -1,0 +1,108 @@
+
+
+from django.test import TestCase
+
+from io import StringIO
+import mock
+
+from .factories import ElectionFactory
+
+from elections.models import Election
+from elections.management.commands import attach_posts_per_election_from_csv
+
+COMMAND_PATH = \
+    "elections.management.commands.attach_posts_per_election_from_csv.Command"
+
+
+class TestAttachPostsPerWard(TestCase):
+    def setUp(self):
+        # This will make one more election object as a parent
+        ElectionFactory.create_batch(5, seats_contested=None)
+
+        self.fake_csv_data = []
+        for election in Election.objects.filter(group_type=None):
+            self.fake_csv_data.append(
+                {
+                    'created': 'yes',
+                    'id': election.election_id,
+                    'posts up': 1,
+                    'seats_total': 2
+                }
+            )
+
+        self.default_options = {
+            'replace_seats_total': False,
+            'skip_unknown': False,
+        }
+
+    @mock.patch(COMMAND_PATH + '.load_csv_data')
+    def test_set_seats_total(self, fake_load_csv_data):
+        fake_load_csv_data.return_value = self.fake_csv_data
+        command_class = attach_posts_per_election_from_csv.Command
+        command = command_class()
+        command.stdout = StringIO(newline=None)
+
+        options = self.default_options
+        options['replace_seats_total'] = True
+        command.handle(**options)
+        self.assertTrue(command.stdout.getvalue().startswith('Taking '))
+
+    @mock.patch(COMMAND_PATH + '.load_csv_data')
+    def test_raise_on_seats_total(self, fake_load_csv_data):
+        fake_load_csv_data.return_value = self.fake_csv_data
+        command_class = attach_posts_per_election_from_csv.Command
+        command = command_class()
+        command.stdout = StringIO()
+
+        options = self.default_options
+        with self.assertRaises(ValueError):
+            command.handle(**options)
+        self.assertEqual(command.stdout.getvalue(), '')
+
+    @mock.patch(COMMAND_PATH + '.load_csv_data')
+    def test_too_many_contested_seats(self, fake_load_csv_data):
+        election = ElectionFactory.create(seats_total=1)
+        election.division.seats_total = 1
+        election.division.save()
+        fake_data = [
+            {
+                'created': 'yes',
+                'id': election.election_id,
+                'posts up': 200,
+                'seats_total': 1
+            }
+        ]
+
+        fake_load_csv_data.return_value = fake_data
+        command_class = attach_posts_per_election_from_csv.Command
+        command = command_class()
+        command.stdout = StringIO()
+
+        options = self.default_options
+        with self.assertRaisesRegexp(ValueError, "seats total less than "):
+            command.handle(**options)
+
+
+    @mock.patch(COMMAND_PATH + '.load_csv_data')
+    def test_skip_unknown(self, fake_load_csv_data):
+        election = ElectionFactory.create(seats_total=None)
+        fake_data = [
+            {
+                'created': 'yes',
+                'id': election.election_id,
+                'posts up': None,
+                'seats_total': None
+            }
+        ]
+
+        fake_load_csv_data.return_value = fake_data
+        command_class = attach_posts_per_election_from_csv.Command
+        command = command_class()
+        command.stdout = StringIO()
+
+        options = self.default_options
+        with self.assertRaisesRegexp(ValueError, "Seats total not known for"):
+            command.handle(**options)
+
+        options['skip_unknown'] = True
+        command.handle(**options)


### PR DESCRIPTION
Add a management command for importing posts per ward from a CSV file.

This command has opinions about `seats_total`. I think that's a good thing, as we should have seats total for everywhere. 

There are options though:

1. If you want to set the seats total from the CSV file then add `--trust-csv-seats-total`
2. If you want to ignore seats total add `--skip-unknown`