### PR TITLE
Attach geographies to mayor/PCC elections

### DIFF
--- a/every_election/apps/elections/models.py
+++ b/every_election/apps/elections/models.py
@@ -123,11 +123,26 @@ class Election(SuggestedByPublicMixin, models.Model):
             return self.tmp_election_id
 
     def get_geography(self):
+        if self.geography:
+            return self.geography
+
         try:
-            if not self.group_type and not self.geography and self.division:
-                return self.division.geography
-            if self.group_type == "organisation" and not self.geography and not self.division:
+
+            # if the election is a 'ballot'
+            if not self.group_type:
+                # attach geography by division if possible
+                if self.division:
+                    return self.division.geography
+                # else try to attach geography by organisation
+                # (e.g: for Mayors, PCCs etc)
+                if not self.division and self.organisation:
+                    return self.organisation.geography
+
+            # if the election is an 'organisation group'
+            # attach geography by organisation
+            if self.group_type == "organisation" and not self.division:
                 return self.organisation.geography
+
         except ObjectDoesNotExist:
             pass
         return None


### PR DESCRIPTION
Since we changed to representing mayor/PCC elections as a ballot rather than an organisation group, elections that we've created recently do not have a geography attached. This means if we call https://elections.democracyclub.org.uk/api/elections.json?postcode=DN121HH&future=1 it tell is there are no elections coming up even though `mayor.sheffield-city-ca.2018-05-03` applies to this area (Doncaster) and so on for a few other areas.

Proposed solution - merge this PR and run:

```python
from elections.models import Election
elections = Election.objects.filter(election_id__in=[
    "mayor.lewisham.2018-05-03",
    "mayor.newham.2018-05-03",
    "mayor.tower-hamlets.2018-05-03",
    "mayor.sheffield-city-ca.2018-05-03",
    "mayor.watford.2018-05-03"])
for e in elections:
    e.geography = e.get_geography()
    e.save()
```

This will also fix this issue moving forwards as `get_geography()` is called on object creation.

Related issue (but for different reasons):

All of the `local.manchester.%.2018-05-03` elections also don't have a geography attached to them (resulting in a similar issue). I assume this is because they were created with just the division names before we had the boundaries.

Proposed solution - run:

```python
from elections.models import Election
elections = Election.objects.filter(
    election_id__startswith="local.manchester.",
    election_id__endswith=".2018-05-03",
    group_type__isnull=True)
for e in elections:
    e.geography = e.get_geography()
    e.save()
```

This doesn't seem to apply to any of the other areas that had boundary changes - I guess I imported the boundaries before we created the ids in all of those areas (with Manchester being an oddity) but I don't quite remember the timeline of it now. Hopefully this will become less common as we are running though the process defined in https://github.com/DemocracyClub/EveryElection/wiki/Updating-Boundaries on a rolling basis, but in principle we may (either on purpose or unwittingly) create more ids when only the names from the ECO are imported. I wonder if there is anything we can do in future to flag this condition, make it more obvious, make it easier to fix, etc..