### PR TITLE
gitignore pytest cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ node_modules/
 every_election/assets-src/vendor/
 .sass-cache/
 *.sqlite
+
+# pytest cache
+.pytest_cache/


### PR DESCRIPTION
Latest version of pytest seems to write some cache files that we don't want to commit