### PR TITLE
add copyright notices

### DIFF
--- a/every_election/templates/base.html
+++ b/every_election/templates/base.html
@@ -93,6 +93,11 @@
         <a href="https://twitter.com/democlub">Twitter</a>
         <a href="https://github.com/DemocracyClub/EveryElection">GitHub</a>
       </p>
+      <p>
+        Contains OS data © Crown copyright and database right {% now "Y" %}<br>
+        Contains Royal Mail data © Royal Mail copyright and database right {% now "Y" %}<br>
+        Contains National Statistics data © Crown copyright and database right {% now "Y" %}<br>
+      </p>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
There are a bunch of notices and attributions we are supposed to have on our site where we use postcode lookups, boundaries, etc (see https://www.ons.gov.uk/methodology/geography/licences ). Lets bung them at the bottom of the footer.