### PR TITLE
Add filter for elections with metadata

### DIFF
--- a/every_election/apps/api/views.py
+++ b/every_election/apps/api/views.py
@@ -56,6 +56,10 @@ class ElectionViewSet(viewsets.ReadOnlyModelViewSet):
         if future is not None:
             queryset = queryset.future()
 
+        with_metadata = self.request.query_params.get('metadata', None)
+        if with_metadata is not None:
+            queryset = queryset.exclude(metadata=None)
+
         return queryset
 
 


### PR DESCRIPTION
Adding this so that it's easy to get a list of elections with a metadata object.

This is mainly for WhoCanIVoteFor's use, so that it doesn't need to iterate over every election to get the ones with metadata in.

Of course it could just look for the key in the response from the postcode lookup, but the current architecture just uses that response to get a list of IDs that are then fed directly in to a queryset. returning the metadata alongside that would be confusing at the moment, or require some refactoring.

Rather than doing that, it's easier to store the metadata on the election object at import time, and this filter speeds that up.