### PR TITLE
reduce boto update noise

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 beautifulsoup4==4.6.0
-boto3==1.7.45
+boto3==1.7.47 # pyup: update minor
 django==1.11.13 # pyup: >=1.11,<2.0
 django-cors-headers==2.3.0
 django-extensions==2.0.7


### PR DESCRIPTION
Boto3 cranks out a new patch release every couple of days and the notifications generate a lot of noise. Extra annoyingly, if you look through the [commit history](https://github.com/boto/boto3/commits/develop), almost all of them do nothing useful. A bot commits some meta-data, bumps the version number and pushes a release to PyPI :scream_cat: 

Making this change will give us a notification when there is a minor version update, but ignore patch releases. This should be a better tradeoff between being able to review updates and not just getting bombarded with noise.

refs https://github.com/pyupio/pyup/issues/277