### PR TITLE
fix icon paths

### DIFF
--- a/every_election/templates/base.html
+++ b/every_election/templates/base.html
@@ -61,15 +61,15 @@
     <link rel="apple-touch-icon" sizes="60x60" href={% static "dc_theme/icons/apple-icon-60x60.png" %}>
     <link rel="apple-touch-icon" sizes="72x72" href={% static "dc_theme/icons/apple-icon-72x72.png" %}>
     <link rel="apple-touch-icon" sizes="76x76" href={% static "dc_theme/icons/apple-icon-76x76.png" %}>
-    <link rel="apple-touch-icon" sizes="114x114" href={% static "icons/apple-icon-114x114.png" %}>
-    <link rel="apple-touch-icon" sizes="120x120" href={% static "icons/apple-icon-120x120.png" %}>
-    <link rel="apple-touch-icon" sizes="144x144" href={% static "icons/apple-icon-144x144.png" %}>
-    <link rel="apple-touch-icon" sizes="152x152" href={% static "icons/apple-icon-152x152.png" %}>
-    <link rel="apple-touch-icon" sizes="180x180" href={% static "icons/apple-icon-180x180.png" %}>
-    <link rel="icon" type="image/png" sizes="192x192"  href={% static "icons/android-icon-192x192.png" %}>
-    <link rel="icon" type="image/png" sizes="32x32" href={% static "icons/favicon-32x32.png" %}>
-    <link rel="icon" type="image/png" sizes="96x96" href={% static "icons/favicon-96x96.png" %}>
-    <link rel="icon" type="image/png" sizes="16x16" href={% static "icons/favicon-16x16.png" %}>
+    <link rel="apple-touch-icon" sizes="114x114" href={% static "dc_theme/icons/apple-icon-114x114.png" %}>
+    <link rel="apple-touch-icon" sizes="120x120" href={% static "dc_theme/icons/apple-icon-120x120.png" %}>
+    <link rel="apple-touch-icon" sizes="144x144" href={% static "dc_theme/icons/apple-icon-144x144.png" %}>
+    <link rel="apple-touch-icon" sizes="152x152" href={% static "dc_theme/icons/apple-icon-152x152.png" %}>
+    <link rel="apple-touch-icon" sizes="180x180" href={% static "dc_theme/icons/apple-icon-180x180.png" %}>
+    <link rel="icon" type="image/png" sizes="192x192"  href={% static "dc_theme/icons/android-icon-192x192.png" %}>
+    <link rel="icon" type="image/png" sizes="32x32" href={% static "dc_theme/icons/favicon-32x32.png" %}>
+    <link rel="icon" type="image/png" sizes="96x96" href={% static "dc_theme/icons/favicon-96x96.png" %}>
+    <link rel="icon" type="image/png" sizes="16x16" href={% static "dc_theme/icons/favicon-16x16.png" %}>
 {% endblock site_icons %}
 
 


### PR DESCRIPTION
Deployed some CSS changes, site broke because we're not using asset fingerprinting. Tried to turn on asset fingerprinting, more stuff broke. This is needed to get fingerprints to work properly.