### PR TITLE
ensure date is a date object, not a string

### DIFF
--- a/every_election/apps/api/views.py
+++ b/every_election/apps/api/views.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from django.http import Http404
 from rest_framework import viewsets
 from rest_framework.decorators import detail_route
@@ -86,6 +87,7 @@ class OrganisationViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = OrganisationSerializer
 
     def get_object(self, **kwargs):
+        kwargs['date'] = datetime.strptime(kwargs['date'], "%Y-%m-%d").date()
         try:
             return Organisation.objects.all().get_by_date(**kwargs)
         except Organisation.DoesNotExist:

--- a/every_election/apps/organisations/views.py
+++ b/every_election/apps/organisations/views.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from django.http import Http404
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.views.generic import ListView, TemplateView
@@ -36,6 +37,7 @@ class OrganisationsFilterView(TemplateView):
 class OrganisationDetailView(TemplateView):
     template_name = "organisations/organisation_detail.html"
     def get_context_data(self, **kwargs):
+        kwargs['date'] = datetime.strptime(kwargs['date'], "%Y-%m-%d").date()
         try:
             obj = Organisation.objects.all().get_by_date(**kwargs)
         except Organisation.DoesNotExist:


### PR DESCRIPTION
fixes `unorderable types: str() < datetime.date()`