### PR TITLE
set a seats_contested value in ElectionBuilder

### DIFF
--- a/every_election/apps/elections/tests/base_tests.py
+++ b/every_election/apps/elections/tests/base_tests.py
@@ -45,7 +45,8 @@ class BaseElectionCreatorMixIn():
         self.org_div_1 = OrganisationDivisionFactory(
             organisation=self.org1,
             name="Test Div 1",
-            slug="test-div"
+            slug="test-div",
+            seats_total=3,
         )
         self.org_div_2 = OrganisationDivisionFactory(
             organisation=self.org1,

--- a/every_election/apps/elections/tests/test_election_builder.py
+++ b/every_election/apps/elections/tests/test_election_builder.py
@@ -89,3 +89,22 @@ class TestElectionBuilder(BaseElectionCreatorMixIn, TestCase):
         # its a child of self.org1
         with self.assertRaises(OrganisationDivision.ValidationError):
             builder.with_division(self.org_div_1)
+
+    def test_seats_contested_local_election(self):
+        builder = ElectionBuilder('local', '2017-06-08')\
+            .with_organisation(self.org1)\
+            .with_division(self.org_div_1)
+        election = builder.build_ballot(None)
+        election.save()
+        self.assertIsNone(election.seats_contested)
+        self.assertEqual(3, election.seats_total)
+
+    def test_seats_contested_local_by_election(self):
+        builder = ElectionBuilder('local', '2017-06-08')\
+            .with_organisation(self.org1)\
+            .with_division(self.org_div_1)\
+            .with_contest_type('by')
+        election = builder.build_ballot(None)
+        election.save()
+        self.assertEqual(1, election.seats_contested)
+        self.assertEqual(3, election.seats_total)

--- a/every_election/apps/elections/utils.py
+++ b/every_election/apps/elections/utils.py
@@ -139,6 +139,38 @@ class ElectionBuilder:
         # otherwise we can rely on the election type
         return self.election_type.default_voting_system
 
+    def get_seats_contested(self):
+        if self.contest_type == "by":
+            # Assume any by-election always elects one representative.
+            # There may be edge cases where we need to edit this via /admin
+            # but this is the best assumption we can make
+            return 1
+
+        if self.election_type.election_type != "local":
+            return 1
+
+        """
+        If this is an all-up local election, we can fairly safely
+        return self.division.seats_total
+        but at the moment we have no way to know if this is 'all-up' or not
+        so doing this is likely to generate a lot of confusing wrong data
+
+        TODO: Add an 'all-up' tickbox to the wizard for local elections
+        Then we can either return
+        self.division.seats_total  or  1
+        here, which will mostly be right
+        ..except for when it isn't
+        ..which will be sometimes
+        """
+
+        # otherwise don't attempt to guess
+        return None
+
+    def get_seats_total(self):
+        if not self.division:
+            return None
+        return self.division.seats_total
+
     def __repr__(self):
         return self.id.__repr__()
 
@@ -230,6 +262,8 @@ class ElectionBuilder:
             'notice': self.notice,
             'source': self.source,
             'snooped_election_id': self.snooped_election_id,
+            'seats_contested': self.get_seats_contested(),
+            'seats_total': self.get_seats_total(),
         })
 
 


### PR DESCRIPTION
Closes #291

As noted in the `TODO` comment, there is some further work to do here which would be useful to get done this side of local elections in May 2019, but that is a bigger job and this will cover the day-to-day by-election churn. I'll raise an issue for that.

There is also going to be some backlog of stuff that has been created since we last manually fixed this that needs manually fixing.