### PR TITLE
pin pytest to <=3.6.4

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -3,7 +3,7 @@
 mock
 model-mommy
 tox
-pytest
+pytest<=3.6.4
 pytest-django
 pytest-pep8
 pytest-flakes


### PR DESCRIPTION
this should be the latest working version that doesn't require code changes in our app to upgrade to it