### PR TITLE
Staging deploy improvements

### DIFF
--- a/every_election/apps/core/context_processors.py
+++ b/every_election/apps/core/context_processors.py
@@ -1,0 +1,6 @@
+from django.conf import settings
+
+def global_settings(request):
+    return {
+        'SERVER_ENVIRONMENT': getattr(settings, 'SERVER_ENVIRONMENT', None)
+    }

--- a/every_election/settings/base.py
+++ b/every_election/settings/base.py
@@ -174,6 +174,7 @@ TEMPLATES = [
                 'django.template.context_processors.static',
                 'django.template.context_processors.tz',
                 'dc_signup_form.context_processors.signup_form',
+                'core.context_processors.global_settings',
             ],
         },
     }

--- a/every_election/settings/base.py
+++ b/every_election/settings/base.py
@@ -84,7 +84,7 @@ LOGGING = {
     }
 }
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -94,6 +94,7 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'basicauth.middleware.BasicAuthMiddleware',
 ]
 
 ROOT_URLCONF = 'every_election.urls'
@@ -240,6 +241,11 @@ AWS_S3_FILE_OVERWRITE = True
 
 EMAIL_SIGNUP_ENDPOINT = 'https://democracyclub.org.uk/mailing_list/api_signup/v1/'
 EMAIL_SIGNUP_API_KEY = ''
+
+
+# Disable Basic Auth by default
+# We only want to use this on staging deploys
+BASICAUTH_DISABLE = True
 
 
 # .local.py overrides all the common settings.

--- a/every_election/templates/base.html
+++ b/every_election/templates/base.html
@@ -14,9 +14,11 @@
 
 {% block top_banner %}
 
-{# <div class="callout warning"> #}
-{#   <p class="text-center">This is an alpha site, so please don't expect anything to work just yet! <a href="https://democracyclub.org.uk/contact/">Get in touch</a> if you'd like to know more.</p> #}
-{# </div> #}
+{% if SERVER_ENVIRONMENT == 'test' or SERVER_ENVIRONMENT == 'staging' %}
+<div class="callout warning">
+  <p class="text-center">This is a staging site.</p>
+</div>
+{% endif %}
 
 <nav class="top-bar">
     <div class="columns large-8 large-centered">

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,7 @@
 beautifulsoup4==4.6.1
 boto3==1.7.47 # pyup: update minor
 django==1.11.15 # pyup: >=1.11,<2.0
+django-basicauth==0.5.1
 django-cors-headers==2.4.0
 django-extensions==2.1.0
 django-filter==2.0.0


### PR DESCRIPTION
This PR does a couple of things relating to staging deploys:

* Use [django-basicauth](https://github.com/hirokiky/django-basicauth) to enable basic auth

    This plugin uses a middleware to negotiate basic auth with the browser without having to involve the web server. This is helpful for our use case because we can configure it in django instead of nginx. Config will look like:

```
BASICAUTH_DISABLE = False
BASICAUTH_REALM = 'Staging'
BASICAUTH_USERS = {
    'staging': 'staging'
}
```

I'll set it conditionally on AWS tags.

* Show a banner in the base template on staging based on the `SERVER_ENVIRONMENT` setting (see https://github.com/DemocracyClub/ee_deploy/pull/14 )
