### PR TITLE
allow URL patterns to be excluded from basic auth

### DIFF
--- a/every_election/apps/core/middleware.py
+++ b/every_election/apps/core/middleware.py
@@ -1,0 +1,16 @@
+import re
+from django.conf import settings
+from basicauth.middleware import BasicAuthMiddleware as BaseBasicAuthMiddleware
+
+class BasicAuthMiddleware(BaseBasicAuthMiddleware):
+
+    def process_request(self, request):
+        always_allow_urls = map(
+            re.compile,
+            getattr(settings, 'BASICAUTH_ALWAYS_ALLOW_URLS', [])
+        )
+        for allowed_url in always_allow_urls:
+            if allowed_url.search(request.path):
+                return None
+
+        return super().process_request(request)

--- a/every_election/settings/base.py
+++ b/every_election/settings/base.py
@@ -94,7 +94,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'basicauth.middleware.BasicAuthMiddleware',
+    'core.middleware.BasicAuthMiddleware',
 ]
 
 ROOT_URLCONF = 'every_election.urls'


### PR DESCRIPTION
This allows us to use middleware and define exclusions using a regex. We only really need to disable one route but if we wanted, we could define something like:

```py
BASICAUTH_ALWAYS_ALLOW_URLS = [
    '^/elections/.*$',
    '^/organisations/$'
]
```

I've nicked this implementation from the old [django-moat](https://github.com/amrox/django-moat) package which is no longer maintained.