### PR TITLE
log a warning if we geocode from mapit

### DIFF
--- a/every_election/apps/elections/query_helpers.py
+++ b/every_election/apps/elections/query_helpers.py
@@ -1,10 +1,15 @@
 import abc
+import logging
 import requests
 
 from django.contrib.gis.geos import Point
 from django.core.exceptions import ObjectDoesNotExist
 
 from uk_geo_utils.geocoders import OnspdGeocoder
+
+
+logger = logging.getLogger(__name__)
+
 
 class PostcodeError(Exception):
     pass
@@ -31,6 +36,9 @@ class BaseMaPitPostcodeLookup(BasePostcodeLookup, metaclass=abc.ABCMeta):
         pass
 
     def fetch_from_mapit(self):
+        logger.warning(
+            'Querying mySociety mapit for postcode {}'.format(self.postcode)
+        )
         if hasattr(self, 'mapit_data'):
             return self.mapit_data
 

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,5 +1,6 @@
 -r base.txt
 
+ec2_tag_conditional==0.1.2
 gunicorn==19.8.1
 jsmin==2.2.2
-ec2_tag_conditional==0.1.2
+raven==6.9.0


### PR DESCRIPTION
closes #339
refs  #391

This doesn't do much other than give us log event to hook into, but if I set up sentry in prod, I'll be able create a sentry log handler and do something like

```py
'elections.query_helpers': {
    'level': 'WARNING',
    'handlers': ['sentry'],
    'propagate': False,
}
```

so we pipe that somewhere visible. (see https://docs.sentry.io/clients/python/integrations/django/#integration-with-logging )

I'll do that in the deploy scripts repo though as it is a production deployment concern as opposed to an application concern.