### PR TITLE
update ACL code for new django-storage behaviour

### DIFF
--- a/every_election/apps/elections/models.py
+++ b/every_election/apps/elections/models.py
@@ -234,6 +234,7 @@ class MetaData(models.Model):
 
 class PdfS3Storage(S3Boto3Storage):
     default_content_type = 'application/pdf'
+    default_acl = 'public-read'
 
 
 class Document(models.Model):

--- a/every_election/settings/base.py
+++ b/every_election/settings/base.py
@@ -238,6 +238,7 @@ AWS_S3_REGION_NAME = 'eu-west-1'
 AWS_STORAGE_BUCKET_NAME = NOTICE_OF_ELECTION_BUCKET
 # versioning is on so we can retreive old copies
 AWS_S3_FILE_OVERWRITE = True
+AWS_DEFAULT_ACL = None
 
 
 EMAIL_SIGNUP_ENDPOINT = 'https://democracyclub.org.uk/mailing_list/api_signup/v1/'


### PR DESCRIPTION
This sets our application default to inherit the target bucket's ACL and explicitly sets the ACL to public-read for election Document objects.

Closes #410