### PR TITLE
explicitly decode bytes in OSNI imports

### DIFF
--- a/every_election/apps/organisations/boundaries/osni.py
+++ b/every_election/apps/organisations/boundaries/osni.py
@@ -34,7 +34,7 @@ class OsniLayer:
             return data
 
     def __init__(self, url, gss_field, name_field):
-        ds = json.loads(self.get_data_from_url(url))
+        ds = json.loads(self.get_data_from_url(url).decode('utf-8'))
         self.features = []
 
         for feature in ds['features']:

--- a/every_election/apps/organisations/boundaries/tests/test_osni_layer.py
+++ b/every_election/apps/organisations/boundaries/tests/test_osni_layer.py
@@ -1,11 +1,10 @@
-import json
 import mock
 from django.contrib.gis.geos import MultiPolygon
 from django.test import TestCase
 from organisations.boundaries.osni import OsniLayer
 
 
-fake_data = json.dumps({
+fake_data = b'''{
   "type": "FeatureCollection",
   "features": [
     {
@@ -52,7 +51,7 @@ fake_data = json.dumps({
       }
     }
   ]
-})
+}'''
 
 
 class OsniLayerTest(TestCase):


### PR DESCRIPTION
Ran into this when I tried running on a staging server.
In python 3.6 `json.loads()` can load from `str` or `bytes`: https://docs.python.org/3/whatsnew/3.6.html#json
In python 3.5 input must be `str`
This fixes for python 3.5 and 3.6