### PR TITLE
ignore .tox in coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 omit =
+    */.tox/*
     */tests/*
     */apps.py
     */migrations/*


### PR DESCRIPTION
strangely the new version of tox didn't cause the same behaviour on this repo as it did on WDIV.. maybe there's something different in tox.ini, but we probably want to do this here too anyway