### PR TITLE
remove some deprecated calls

### DIFF
--- a/every_election/apps/api/views.py
+++ b/every_election/apps/api/views.py
@@ -30,7 +30,7 @@ class ElectionViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Election.public_objects.all()
     serializer_class = ElectionSerializer
     lookup_field = 'election_id'
-    lookup_value_regex = "(?!\.json$)[^/]+"
+    lookup_value_regex = r"(?!\.json$)[^/]+"
     filter_fields = ('group_type', 'poll_open_date')
 
     @action(detail=True, url_path='geo')

--- a/every_election/apps/api/views.py
+++ b/every_election/apps/api/views.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from django.http import Http404
 from rest_framework import viewsets
-from rest_framework.decorators import detail_route
+from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.exceptions import APIException
 
@@ -33,7 +33,7 @@ class ElectionViewSet(viewsets.ReadOnlyModelViewSet):
     lookup_value_regex = "(?!\.json$)[^/]+"
     filter_fields = ('group_type', 'poll_open_date')
 
-    @detail_route(url_path='geo')
+    @action(detail=True, url_path='geo')
     def geo(self, request, election_id=None, format=None):
         election = self.get_queryset().get(election_id=election_id)
         return Response(ElectionGeoSerializer(election,
@@ -103,7 +103,7 @@ class OrganisationViewSet(viewsets.ReadOnlyModelViewSet):
         except Organisation.DoesNotExist:
             raise Http404()
 
-    @detail_route(url_path='geo')
+    @action(detail=True, url_path='geo')
     def geo(self, request, **kwargs):
         kwargs.pop('format', None)
         org = self.get_object(**kwargs)

--- a/every_election/apps/elections/tests/test_attach_posts_command.py
+++ b/every_election/apps/elections/tests/test_attach_posts_command.py
@@ -77,7 +77,7 @@ class TestAttachPostsPerWard(TestCase):
         command.stdout = StringIO()
 
         options = self.default_options
-        with self.assertRaisesRegexp(ValueError, "seats total less than "):
+        with self.assertRaisesRegex(ValueError, "seats total less than "):
             command.handle(**options)
 
 
@@ -99,7 +99,7 @@ class TestAttachPostsPerWard(TestCase):
         command.stdout = StringIO()
 
         options = self.default_options
-        with self.assertRaisesRegexp(ValueError, "Seats total not known for"):
+        with self.assertRaisesRegex(ValueError, "Seats total not known for"):
             command.handle(**options)
 
         options['skip_unknown'] = True

--- a/every_election/apps/storage/shapefile.py
+++ b/every_election/apps/storage/shapefile.py
@@ -44,7 +44,7 @@ def _convert_multipolygons_to_latlong(features, srid):
     # ensure our .multipolygon property uses srid 4326
     for feature in features:
         if not feature.multipolygon.srid:
-            feature.multipolygon.set_srid(srid)
+            feature.multipolygon.srid = srid
         feature.multipolygon.transform(4326)
     return features
 

--- a/every_election/urls.py
+++ b/every_election/urls.py
@@ -12,7 +12,7 @@ urlpatterns = [
     url(r'^$', HomeView.as_view(), name="home"),
     url(r'^organisations/', include('organisations.urls')),
     url(r'', include('elections.urls')),
-    url(r'^api/', include('api.urls', namespace='api')),
+    url(r'^api/', include(('api.urls', 'api'), namespace='api')),
     url('^markdown/', include('django_markdown.urls')),
     url(r'^election_radar/', include('election_snooper.urls')),
     url(r'^email/', include('dc_signup_form.urls')),


### PR DESCRIPTION
This fixes the following deprecation warnings:

* `DeprecationWarning: detail_route is deprecated and will be removed in 3.10 in favor of action, which accepts a detail bool. Use @action(detail=True) instead`
* `RemovedInDjango20Warning: Specifying a namespace in django.conf.urls.include() without providing an app_name is deprecated. Set the app_name attribute in the included module, or pass a 2-tuple containing the list of patterns and app_name instead.`
* `DeprecationWarning: Please use assertRaisesRegex instead.`
* `RemovedInDjango20Warning: set_srid() is deprecated, use the srid property instead.`
* `DeprecationWarning: invalid escape sequence \.`