### PR TITLE
only allow ballots to be cancelled

### DIFF
--- a/every_election/apps/elections/admin.py
+++ b/every_election/apps/elections/admin.py
@@ -35,6 +35,12 @@ class ElectionAdmin(admin.ModelAdmin):
         'cancellation_notice',
     )
 
+    def get_readonly_fields(self, request, obj=None):
+        if not obj.group_type:
+            return self.readonly_fields
+        else:
+            return self.readonly_fields + ('cancelled',)
+
     def render_change_form(self, request, context, *args, **kwargs):
         context['adminform'].form.fields['replaces'].queryset = Election\
             .public_objects\


### PR DESCRIPTION
Because everything internal that consumes our data treats ballots and election as different concepts I've only implemented it at the ballot level. As such, its probably unhelpful (for now) to cancel a group because we can't really do anything useful with that data point.