### PR TITLE
check for conflicting dependencies in CI build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,8 @@ skipsdist = True
 deps = -r{toxinidir}/requirements/testing.txt
 
 commands =
+    pip check
     python manage.py check
     pytest --flake
-    pytest
     pytest --cov-report= --cov=every_election
     # pytest --pep8


### PR DESCRIPTION
This will fail the build until we can upgrade DRF-GIS to 0.14 but after that, this should stop us from doing that again ( #433 was the other blocker on this)