### PR TITLE
Fix styling of details>summary element

### DIFF
--- a/every_election/apps/organisations/templates/organisations/supported_organisations.html
+++ b/every_election/apps/organisations/templates/organisations/supported_organisations.html
@@ -1,5 +1,14 @@
 {% extends "base.html" %}
 
+{% block extra_page_css %}
+<style>
+@-moz-document url-prefix() {
+  summary {
+    display: list-item;
+  }
+}
+</style>
+{% endblock extra_page_css %}
 
 {% block content %}
 <section class="columns large-6 large-centered">


### PR DESCRIPTION
refs #378

It turns out the main reason I found this really confusing is because the base theme styles this element sensibly in Chromium-based browsers but not Firefox, and I use Firefox :fox_face: 


Firefox:

![screenshot at 2018-12-21 16-00-24](https://user-images.githubusercontent.com/6025893/50351751-04029c00-053b-11e9-9f2e-edb336d09611.png)


Chromium Stable:

![screenshot at 2018-12-21 16-00-36](https://user-images.githubusercontent.com/6025893/50351761-0a911380-053b-11e9-8a92-9637e96235ae.png)



I've proposed a hacky fix here mainly just so that I remember it, but we should probably fix this in the base theme, tag a patch release and upgrade EE. Happy to propose a PR to the theme if I can get a pointer on where in the v0.2 theme this should live.