### PR TITLE
add division types for new local auths

### DIFF
--- a/every_election/apps/organisations/constants.py
+++ b/every_election/apps/organisations/constants.py
@@ -584,6 +584,11 @@ ORG_CURIE_TO_MAPIT_AREA_TYPE = {
     "local-authority-wls:BGW": "UTA",
     "local-authority-wls:BGE": "UTA",
     "local-authority-wls:AGY": "UTA",
+    "local-authority-eng:BPC": "UTA",
+    "local-authority-eng:DST": "UTA",
+    "local-authority-eng:SWT": "DIS",
+    "local-authority-eng:WSK": "DIS",
+    "local-authority-eng:ESK": "DIS",
 }
 
 


### PR DESCRIPTION
We need this mapping in order to import the divisions for the new areas

I'd like to move into the DB so its a property of the Organisation model, but not today..