### PR TITLE
add 'europarl' to ORGTYPES

### DIFF
--- a/every_election/apps/organisations/models/organisations.py
+++ b/every_election/apps/organisations/models/organisations.py
@@ -36,6 +36,7 @@ class Organisation(models.Model):
         ("parl", "parl"),
         ("police-area", "police-area"),
         ("sp", "sp"),
+        ("europarl", "europarl"),
     )
 
     official_identifier = models.CharField(blank=False, max_length=255, db_index=True)


### PR DESCRIPTION
I've manually fiddled this in the console for now, but we can't edit the "European Union Parliament" organisation record via /admin until we merge this.