### PR TITLE
don't prompt for divisions on PCC elections

### DIFF
--- a/every_election/apps/elections/views/id_creator.py
+++ b/every_election/apps/elections/views/id_creator.py
@@ -87,7 +87,7 @@ def select_organisation_division(wizard):
     election_type = wizard.get_election_type()
     if not election_type:
         return False
-    if wizard.get_election_type().election_type == "mayor":
+    if wizard.get_election_type().election_type in ["mayor", "pcc"]:
         return False
     return True
 


### PR DESCRIPTION
This stops us showing the "pick divisions" step in the wizard for PCC elections (which don't use divisions).

What this doesn't solve is that it still won't be a `.by` because we don't have the ability to specify whether a Mayor/PCC election is planned or not.

I reckon in the immediate term, I'll create this one and then manually edit the ID. As a bit of future work, we do need to think about adding a wizard step which allows us to specify this when the representative is directly elected to the organisation instead of a divsion.