### PR TITLE
zero downtime ONSPD import

### DIFF
--- a/every_election/apps/core/management/commands/import_onspd_remote.py
+++ b/every_election/apps/core/management/commands/import_onspd_remote.py
@@ -3,12 +3,22 @@ import psutil
 import shutil
 import tempfile
 import urllib.request
+import sqlparse
 from django.core.management.base import BaseCommand
+from django.db import connection
+from django.db import transaction
 from storage.zipfile import unzip
 from uk_geo_utils.management.commands.import_onspd import Command as LocalImporter
+from uk_geo_utils.helpers import get_onspd_model
 
 
 class Command(BaseCommand):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.cursor = connection.cursor()
+        self.table_name = get_onspd_model()._meta.db_table
+        self.temp_table_name = self.table_name + "_temp"
+
     def add_arguments(self, parser):
         parser.add_argument("url", action="store")
 
@@ -23,6 +33,68 @@ class Command(BaseCommand):
         gb = ((mem.total / 1024) / 1024) / 1024
         return gb >= 2
 
+    def get_index_statements(self):
+        self.cursor.execute(
+            "SELECT indexdef FROM pg_indexes WHERE tablename='%s' ORDER BY indexname LIKE '%%_pk' DESC;"
+            % (self.table_name)
+        )
+        results = self.cursor.fetchall()
+
+        indexes = []
+        statements = [row[0] for row in results]
+        for statement in statements:
+            indexes.append(
+                {
+                    "original_index_create_statement": statement,
+                    "temp_index_create_statement": "",
+                    "index_rename_statement": "",
+                }
+            )
+
+        for index in indexes:
+            index["temp_index_create_statement"] = index[
+                "original_index_create_statement"
+            ].replace(self.table_name, self.temp_table_name)
+
+            # split the SQL string into a list of sqlparse.sql.Token objects
+            # https://sqlparse.readthedocs.io/en/latest/analyzing/
+            parsed_sql = sqlparse.parse(index["original_index_create_statement"])[0]
+
+            # we expect the statement to be of the form
+            # CREATE [UNIQUE] INDEX $index ON $table USING $fields"
+            # attempt to extract $index and $table
+            identifiers = [
+                token.value
+                for token in parsed_sql.tokens
+                if not token.ttype and self.table_name in token.value
+            ]
+            if len(identifiers) != 2:
+                raise Exception("Expected 2 identifiers, found %i" % len(identifiers))
+
+            original_index_name = identifiers[0]
+            temp_index_name = original_index_name.replace(
+                self.table_name, self.temp_table_name
+            )
+            index["index_rename_statement"] = "ALTER INDEX %s RENAME TO %s" % (
+                temp_index_name,
+                original_index_name,
+            )
+
+        return indexes
+
+    def create_temp_table(self):
+        self.cursor.execute("DROP TABLE IF EXISTS %s;" % (self.temp_table_name))
+        self.cursor.execute(
+            "CREATE TABLE %s AS SELECT * FROM %s LIMIT 0;"
+            % (self.temp_table_name, self.table_name)
+        )
+
+    def swap_tables(self):
+        self.cursor.execute("DROP TABLE %s;" % (self.table_name))
+        self.cursor.execute(
+            "ALTER TABLE %s RENAME TO %s;" % (self.temp_table_name, self.table_name)
+        )
+
     def handle(self, **options):
         if not self.check_memory():
             raise Exception(
@@ -35,11 +107,45 @@ class Command(BaseCommand):
         urllib.request.urlretrieve(url, tmp.name)
         tempdir = unzip(tmp.name)
         data_path = os.path.join(tempdir, "Data")
+
         try:
+            self.stdout.write("Creating temp table..")
+            self.create_temp_table()
+
+            # import ONSPD into the temp table
             cmd = LocalImporter()
-            cmd.handle(**{"path": data_path, "transaction": False})
+            cmd.table_name = self.temp_table_name
+            cmd.path = data_path
+            cmd.import_onspd()
+
+            # grab the index CREATE statements from the old table before
+            # we drop it. This will ensure we create the indexes on the
+            # new table with the exact names django expects them to have
+            # (e.g: uk_geo_utils_onspd_pcds_9d376544_uniq )
+            # so we can still run migrations and stuff on it
+            indexes = self.get_index_statements()
+
+            self.stdout.write("Building indexes..")
+            for index in indexes:
+                self.cursor.execute(index["temp_index_create_statement"])
+
+            # drop the old table, swap in the new one and rename the indexes
+            # do this bit in a transaction so if it fails
+            # we don't leave ourselves in an inconsistent state
+            with transaction.atomic():
+                self.stdout.write("Swapping tables..")
+                self.swap_tables()
+
+                self.stdout.write("Renaming indexes..")
+                for index in indexes:
+                    self.cursor.execute(index["index_rename_statement"])
+
         finally:
+            self.cursor.execute("DROP TABLE IF EXISTS %s;" % (self.temp_table_name))
+            self.stdout.write("Cleaning up temp files..")
             self.cleanup(tempdir)
+
+        self.stdout.write("...done")
 
     def cleanup(self, tempdir):
         # clean up the temp files we created

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,6 +21,7 @@ psycopg2-binary==2.8.3
 requests==2.22.0
 retry==0.9.2
 six==1.12.0
+sqlparse==0.3.0
 uk-election-ids==0.1.2
 uk-geo-utils==0.8.0
 


### PR DESCRIPTION
Quick background on this:

* Importing ONSPD takes ~10 mins, or whatever.
* If you do the import in a transaction, it locks the table for the full 10 mins and every API request with a postcode issues a 503 while you're doing it and that has a knock-on effect on WDIV, WCIF, etc.
* If you don't do it in a transaction, you can get spurious/incorrect results during that 10 minute window.
* Now that we've got rid of the code that queries mySociety's mapit, we can't use that as a fallback anymore (also, rate limits, etc).

At a high-level, this PR solves the problem by:
* Creating a temp table
* Importing the data into the temp table
* Swapping the tables over
(its slightly more fiddly than that)

With this approach, we stay queryable throughout the process.
Once I've run this in production a few times and I'm happy with the process, I'll probably generalise and upstream this to the uk-geo-utils package but for now I think its easier for it to live here. In general, its probably a useful thing to have worked out a technique for.

Closes https://github.com/DemocracyClub/EveryElection/issues/340
Closes https://trello.com/c/6hk83eIr
Closes https://trello.com/c/ks9LfU3K
Refs https://github.com/DemocracyClub/EveryElection/issues/544