### PR TITLE
make sure <section>s are always in a <div class="row">

### DIFF
--- a/every_election/apps/election_snooper/templates/election_snooper/moderation_queue.html
+++ b/every_election/apps/election_snooper/templates/election_snooper/moderation_queue.html
@@ -3,7 +3,8 @@
 
 {% block content %}
 
-<section class="columns large-8 large-centered">
+<div class="row">
+<section class="columns large-12 large-centered">
     {% include "election_snooper/sub_menu.html" %}
 
     {% for form in forms %}
@@ -36,4 +37,5 @@
     {% endfor %}
 
 </section>
+</div>
 {% endblock content %}

--- a/every_election/apps/election_snooper/templates/election_snooper/snooped_election_list.html
+++ b/every_election/apps/election_snooper/templates/election_snooper/snooped_election_list.html
@@ -3,7 +3,8 @@
 
 {% block content %}
 
-<section class="columns large-8 large-centered">
+<div class="row">
+<section class="columns large-12 large-centered">
     {% include "election_snooper/sub_menu.html" %}
 
     {% for form in objects %}
@@ -48,4 +49,5 @@
     {% include "core/pagination_links.html" %}
 
 </section>
+</div>
 {% endblock content %}

--- a/every_election/apps/elections/templates/elections/election_detail.html
+++ b/every_election/apps/elections/templates/elections/election_detail.html
@@ -2,7 +2,8 @@
 {% load dc_forms %}
 
 {% block content %}
-<section class="columns large-6 large-centered">
+<div class="row">
+<section class="columns large-10 large-centered">
 
     <div class="card postcode_card election">
         <h1>{% if object.election_title %}
@@ -132,6 +133,7 @@
 
     </div>
 </section>
+</div>
 
 {% endblock content %}
 

--- a/every_election/apps/elections/templates/elections/election_types.html
+++ b/every_election/apps/elections/templates/elections/election_types.html
@@ -2,7 +2,8 @@
 
 
 {% block content %}
-<section class="columns large-6 large-centered">
+<div class="row">
+<section class="columns large-10 large-centered">
 
   <div class="card postcode_card">
       <h2>Election Types</h2>
@@ -30,4 +31,5 @@
   </div>
 
 </section>
+</div>
 {% endblock content %}

--- a/every_election/apps/elections/templates/elections/elections.html
+++ b/every_election/apps/elections/templates/elections/elections.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
 
 {% block content %}
-<section class="columns large-6 large-centered">
+<div class="row">
+<section class="columns large-10 large-centered">
 
   <div class="card postcode_card">
 
@@ -39,4 +40,5 @@
   </div>
 
 </section>
+</div>
 {% endblock content %}

--- a/every_election/apps/elections/templates/elections/reference_definition.html
+++ b/every_election/apps/elections/templates/elections/reference_definition.html
@@ -2,7 +2,8 @@
 
 
 {% block content %}
-<section class="columns large-6 large-centered">
+<div class="row">
+<section class="columns large-10 large-centered">
 
   <div class="card postcode_card">
     <h2>Election Identifier Reference</h2>
@@ -141,4 +142,5 @@
   </div>
 
 </section>
+</div>
 {% endblock content %}

--- a/every_election/apps/elections/templates/id_creator/id_creator_base.html
+++ b/every_election/apps/elections/templates/id_creator/id_creator_base.html
@@ -3,8 +3,9 @@
 
 {% block content %}
 
-
-<div class="columns large-8 large-centered card">
+<div class="row">
+<section class="columns large-10 large-centered">
+  <div class="columns card">
     {# <p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p> #}
     {% block form_page_header %}{% endblock form_page_header %}
     <form action="" method="post" {% block form_tag_extra %}{% endblock form_tag_extra %}>
@@ -32,5 +33,7 @@
     {% endblock wizard_buttons %}
 
     </form>
+  </div>
+</section>
 </div>
 {% endblock content %}

--- a/every_election/apps/organisations/templates/organisations/organisation_detail.html
+++ b/every_election/apps/organisations/templates/organisations/organisation_detail.html
@@ -2,7 +2,8 @@
 
 
 {% block content %}
-<section class="columns large-6 large-centered">
+<div class="row">
+<section class="columns large-10 large-centered">
 
     <div class="card postcode_card">
 
@@ -70,5 +71,6 @@
         </ul>
     </div>
 </section>
+</div>
 
 {% endblock content %}

--- a/every_election/apps/organisations/templates/organisations/organisation_filter.html
+++ b/every_election/apps/organisations/templates/organisations/organisation_filter.html
@@ -2,7 +2,8 @@
 
 
 {% block content %}
-<section class="columns large-6 large-centered">
+<div class="row">
+<section class="columns large-10 large-centered">
 
 {% for object in objects %}
   <div class="card postcode_card">
@@ -13,4 +14,5 @@
 {% include "core/pagination_links.html" %}
 
 </section>
+</div>
 {% endblock content %}

--- a/every_election/apps/organisations/templates/organisations/supported_organisations.html
+++ b/every_election/apps/organisations/templates/organisations/supported_organisations.html
@@ -11,7 +11,8 @@
 {% endblock extra_page_css %}
 
 {% block content %}
-<section class="columns large-6 large-centered">
+<div class="row">
+<section class="columns large-10 large-centered">
 
   <div class="card postcode_card">
       <h2>Supported Organisations</h2>
@@ -36,4 +37,5 @@
   </div>
 
 </section>
+</div>
 {% endblock content %}


### PR DESCRIPTION
I just noticed there are a bunch of templates where the page content flows into the footer in a narrow window. This fixes them.

**before**
![Screenshot at 2019-06-21 10-50-39](https://user-images.githubusercontent.com/6025893/59914783-fe670f80-9412-11e9-8118-847c3f5f8283.png)

**after**
![Screenshot at 2019-06-21 10-51-02](https://user-images.githubusercontent.com/6025893/59914785-0030d300-9413-11e9-905c-b36a1ee0102f.png)