### PR TITLE
add identifier_type property

### DIFF
--- a/every_election/apps/api/management/commands/export_boundaries.py
+++ b/every_election/apps/api/management/commands/export_boundaries.py
@@ -134,13 +134,13 @@ class Command(BaseCommand):
         return geojson.FeatureCollection(features, election_group=parent.election_id)
 
     def get_ballots(self, group):
-        " Return the leaf-level ballots for a group of elections. "
+        " Return the ballots for a group of elections. "
         to_visit = [group]
         leaf_nodes = []
         while len(to_visit) > 0:
             e = to_visit.pop()
             children = e.get_children("public_objects").all()
-            if not children and e.group_type in ["organisation", None]:
+            if e.identifier_type == "ballot":
                 leaf_nodes.append(e)
             else:
                 to_visit += children

--- a/every_election/apps/api/serializers.py
+++ b/every_election/apps/api/serializers.py
@@ -157,6 +157,7 @@ election_fields = (
     "organisation",
     "group",
     "group_type",
+    "identifier_type",
     "children",
     "elected_role",
     "seats_contested",

--- a/every_election/apps/api/views.py
+++ b/every_election/apps/api/views.py
@@ -75,6 +75,13 @@ class ElectionViewSet(viewsets.ReadOnlyModelViewSet):
         if self.request.query_params.get("metadata", None) is not None:
             queryset = queryset.exclude(metadata=None)
 
+        identifier_type = self.request.query_params.get("identifier_type", None)
+        if identifier_type is not None:
+            if identifier_type == "ballot":
+                queryset = queryset.filter(group_type=None)
+            else:
+                queryset = queryset.filter(group_type=identifier_type)
+
         queryset = queryset.select_related(
             "election_type", "organisation", "elected_role", "division"
         )

--- a/every_election/apps/api/views.py
+++ b/every_election/apps/api/views.py
@@ -47,7 +47,8 @@ class ElectionViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         queryset = Election.public_objects.all()
-        if self.request.query_params.get("deleted", None):
+
+        if self.request.query_params.get("deleted", None) is not None:
             queryset = Election.private_objects.all().filter_by_status("Deleted")
 
         postcode = self.request.query_params.get("postcode", None)
@@ -65,16 +66,13 @@ class ElectionViewSet(viewsets.ReadOnlyModelViewSet):
                 raise APICoordsException()
             queryset = queryset.for_lat_lng(lat=lat, lng=lng)
 
-        current = self.request.query_params.get("current", None)
-        if current is not None:
+        if self.request.query_params.get("current", None) is not None:
             queryset = queryset.current()
 
-        future = self.request.query_params.get("future", None)
-        if future is not None:
+        if self.request.query_params.get("future", None) is not None:
             queryset = queryset.future()
 
-        with_metadata = self.request.query_params.get("metadata", None)
-        if with_metadata is not None:
+        if self.request.query_params.get("metadata", None) is not None:
             queryset = queryset.exclude(metadata=None)
 
         queryset = queryset.select_related(

--- a/every_election/apps/elections/admin.py
+++ b/every_election/apps/elections/admin.py
@@ -36,7 +36,7 @@ class ElectionAdmin(admin.ModelAdmin):
     )
 
     def get_readonly_fields(self, request, obj=None):
-        if not obj.group_type:
+        if obj.identifier_type == "ballot":
             return self.readonly_fields
         else:
             return self.readonly_fields + ("cancelled",)

--- a/every_election/apps/elections/migrations/0056_cleanup_group_types.py
+++ b/every_election/apps/elections/migrations/0056_cleanup_group_types.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+group_type_map = {
+    # These mayoral elections all have group_type='organisation', but they should
+    # be None to bring them into line with the current convention for mayor/pcc
+    "mayor.west-of-england.2017-05-04": None,
+    "mayor.cambridgeshire-and-peterborough.2017-05-04": None,
+    "mayor.north-tyneside.2017-05-04": None,
+    "mayor.hackney.2018-05-03": None,
+    "mayor.doncaster.2017-05-04": None,
+    "mayor.tees-valley.2017-05-04": None,
+    "mayor.greater-manchester-ca.2017-05-04": None,
+    "mayor.west-midlands.2017-05-04": None,
+    "mayor.liverpool-city-ca.2017-05-04": None,
+    # These election groups have group_type='' for some reason
+    "nia.1998-06-25": "election",
+    "parl.2000-09-21": "election",
+    "nia.2003-11-26": "election",
+    "nia.2007-03-07": "election",
+    "nia.2011-05-05": "election",
+    "parl.2011-06-09": "election",
+    "parl.2013-03-07": "election",
+    "local.2014-05-22": "election",
+    "nia.2016-05-05": "election",
+    # These organisation groups have group_type='' for some reason
+    "local.belfast.2011-05-05": "organisation",
+    "local.antrim-and-newtownabbey.2014-05-22": "organisation",
+    "local.ards-and-north-down.2014-05-22": "organisation",
+    "local.armagh-city-banbridge-and-craigavon.2014-05-22": "organisation",
+    "local.belfast.2014-05-22": "organisation",
+    "local.causeway-coast-and-glens.2014-05-22": "organisation",
+    "local.derry-city-and-strabane.2014-05-22": "organisation",
+    "local.fermanagh-and-omagh.2014-05-22": "organisation",
+    "local.lisburn-and-castlereagh.2014-05-22": "organisation",
+    "local.mid-and-east-antrim.2014-05-22": "organisation",
+    "local.mid-ulster.2014-05-22": "organisation",
+    "local.newry-mourne-and-down.2014-05-22": "organisation",
+}
+
+
+def fix_bad_group_types(apps, schema_editor):
+    for election_id, group_type in group_type_map.items():
+        Election = apps.get_model("elections", "Election")
+        try:
+            e = Election.private_objects.get(election_id=election_id)
+            e.group_type = group_type
+            e.save()
+        except Election.DoesNotExist:
+            # don't throw an exception
+            # if we're initializing an enpty DB
+            pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("elections", "0055_auto_20181204_0918")]
+
+    operations = [migrations.RunPython(fix_bad_group_types, migrations.RunPython.noop)]

--- a/every_election/apps/elections/models.py
+++ b/every_election/apps/elections/models.py
@@ -248,7 +248,7 @@ class Election(models.Model):
 
     @property
     def geography(self):
-        if not self.group_type and self.division:
+        if self.identifier_type == "ballot" and self.division:
             return self.division_geography
         return self.organisation_geography
 
@@ -263,8 +263,7 @@ class Election(models.Model):
             return self.division_geography
 
         try:
-            # if the election is a 'ballot'
-            if not self.group_type:
+            if self.identifier_type == "ballot":
                 # attach geography by division if possible
                 if self.division:
                     return self.division.geography
@@ -274,7 +273,7 @@ class Election(models.Model):
 
     @property
     def ynr_link(self):
-        if self.group_type == "organisation" or not self.group_type:
+        if self.identifier_type in ["organisation", "ballot"]:
             return "https://candidates.democracyclub.org.uk/elections/{}".format(
                 self.election_id
             )
@@ -282,7 +281,7 @@ class Election(models.Model):
 
     @property
     def whocivf_link(self):
-        if self.group_type == "organisation" or not self.group_type:
+        if self.identifier_type in ["organisation", "ballot"]:
             return "https://whocanivotefor.co.uk/elections/{}".format(self.election_id)
         return None
 
@@ -291,8 +290,7 @@ class Election(models.Model):
             return self.organisation_geography
 
         try:
-            # if the election is a 'ballot'
-            if not self.group_type:
+            if self.identifier_type == "ballot":
 
                 if self.division:
                     return None
@@ -312,7 +310,7 @@ class Election(models.Model):
         return None
 
     def clean(self):
-        if self.group_type and self.cancelled:
+        if not self.identifier_type == "ballot" and self.cancelled:
             raise ValidationError(
                 "Can't set a group to cancelled. Only a ballot can be cancelled"
             )

--- a/every_election/apps/elections/models.py
+++ b/every_election/apps/elections/models.py
@@ -252,6 +252,12 @@ class Election(models.Model):
             return self.division_geography
         return self.organisation_geography
 
+    @property
+    def identifier_type(self):
+        if not self.group_type:
+            return "ballot"
+        return self.group_type
+
     def get_division_geography(self):
         if self.division_geography:
             return self.division_geography

--- a/every_election/apps/elections/templates/elections/election_detail.html
+++ b/every_election/apps/elections/templates/elections/election_detail.html
@@ -37,7 +37,7 @@
               </dd>
         {% endif %}
 
-        {% if object.group_type == 'organisation' or not object.group_type %}
+        {% if object.identifier_type == "organisation" or object.identifier_type == "ballot" %}
             {% if object.voting_system %}
             <dt>Voting system</dt><dd><a href="{{ object.voting_system.wikipedia_url }}">
                 {{ object.voting_system }}</a></dd>

--- a/every_election/apps/elections/templates/id_creator/review.html
+++ b/every_election/apps/elections/templates/id_creator/review.html
@@ -15,7 +15,7 @@
 
 <h2>Group IDs</h2>
 {% for election in all_ids %}
-    {% if election.group_type %}
+    {% if not election.identifier_type == "ballot" %}
     <h3><code>{{ election.election_id }}</code></h3>
     {% endif %}
 {% endfor %}
@@ -27,7 +27,7 @@
     {% if election_group.grouper %}
     <h3>{{ election_group.grouper }}</h3>
     {% for election in election_group.list %}
-        {% if not election.group_type %}
+        {% if election.identifier_type == "ballot" %}
         <h3><code>{{ election.election_id }}</code></h3>
         {% endif %}
     {% endfor %}

--- a/every_election/apps/elections/tests/test_create_ids.py
+++ b/every_election/apps/elections/tests/test_create_ids.py
@@ -194,6 +194,11 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
 
         self.run_test_with_data(all_data, expected_ids, expected_titles)
 
+        ballot = Election.private_objects.get(
+            election_id="mayor.test-ca." + self.date_str
+        )
+        self.assertIsNone(ballot.group_type)
+
     def test_creates_parl_id(self):
         parl_org = Organisation.objects.create(
             official_identifier="parl",


### PR DESCRIPTION
Following on from my last comment in https://github.com/DemocracyClub/aggregator-api/pull/56#issue-292868216

> Finally, one thing I realise as I think about documenting the API outputs is that the way we identify a ballot is not very nice. At the moment `"group_type": null` is the thing that tells you if an election is a ballot or a group. As an outsider, it feels like a bit of a strange way to expose quite a key bit of info though. What do you think of changing that to `"group_type": "ballot"` or adding an extra key like `"ballot": true/false`?

I wanted to add an `is_ballot` property to the API. Inevitably once I got into it, some worms came out  of the can.. They were small worms though.

I think it makes more sense to characterise this as `"is_ballot": true/false` as opposed to `"group_type": "ballot"` but I'll leave this one open for feedback.

This might also possibly allow us to slightly simplify the EE import code in YNR, but I've not checked it..