### PR TITLE
Order subdivisions by type on organisation page

### DIFF
--- a/every_election/apps/organisations/models/divisions.py
+++ b/every_election/apps/organisations/models/divisions.py
@@ -31,6 +31,16 @@ class OrganisationDivisionSet(DateConstraintMixin, models.Model):
                 pass
         return found_geography
 
+    def divisions_by_type(self):
+        divisions_by_type = {}
+        divisions = self.divisions.all()
+        for division in divisions:
+            if division.division_type not in divisions_by_type:
+                divisions_by_type[division.division_type] = [division]
+            else:
+                divisions_by_type[division.division_type].append(division)
+        return divisions_by_type
+
     def save(self, *args, **kwargs):
         self.check_end_date()
         return super().save(*args, **kwargs)

--- a/every_election/apps/organisations/templates/organisations/organisation_detail.html
+++ b/every_election/apps/organisations/templates/organisations/organisation_detail.html
@@ -38,21 +38,23 @@
                 </tr>
             </thead>
             <tbody>
-            {% for division in divisionset.divisions.all %}
-                <tr>
-                    <td>{{ division }}</td>
-                    <td>{{ division.seats_total|default_if_none:"Unknown" }}</td>
-                    <td>{{ division.division_subtype }}</td>
-                    <td>
-                        {% if division.format_geography_link %}
-                        <a href="{{ division.format_geography_link }}.html">
-                            {{ division.official_identifier }}
-                        </a>
-                        {% else %}
-                        <strong>Missing</strong>
-                        {% endif %}
-                    </td>
-                </tr>
+            {% for division_type, divisions in divisionset.divisions_by_type.items %}
+                {% for division in divisions %}
+                    <tr>
+                        <td>{{ division }}</td>
+                        <td>{{ division.seats_total|default_if_none:"Unknown" }}</td>
+                        <td>{{ division.division_subtype }}</td>
+                        <td>
+                            {% if division.format_geography_link %}
+                            <a href="{{ division.format_geography_link }}.html">
+                                {{ division.official_identifier }}
+                            </a>
+                            {% else %}
+                            <strong>Missing</strong>
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
             {% endfor %}
             </tbody>
             </table>


### PR DESCRIPTION
Implements #466 
At the moment the regions and constituencies are all in one table, but grouped together. This didn't seem unreasonable - but I wondered if the intention was to have one table per subdivision type?
At any rate its worth checking that the general approach is sensible before doing any more.