### PR TITLE
fix organisation names in wizard

### DIFF
--- a/every_election/apps/elections/forms.py
+++ b/every_election/apps/elections/forms.py
@@ -55,6 +55,11 @@ class ElectionSubTypeForm(forms.Form):
     )
 
 
+class ElectionOrganisationField(forms.ModelMultipleChoiceField):
+    def label_from_instance(self, obj):
+        return obj.name
+
+
 class ElectionOrganisationForm(forms.Form):
     def __init__(self, *args, **kwargs):
         election_type = kwargs.pop("election_type", None)
@@ -75,7 +80,7 @@ class ElectionOrganisationForm(forms.Form):
             else:
                 self.fields["election_organisation"].queryset = qs
 
-    election_organisation = forms.ModelMultipleChoiceField(
+    election_organisation = ElectionOrganisationField(
         queryset=Organisation.objects.all(), widget=forms.CheckboxSelectMultiple
     )
 


### PR DESCRIPTION
We missed this in review, but after changing Organisation's `str()` method in PR #661 the org names are a bit excessively detailed in the wizard:

![Screenshot at 2020-02-10 17-36-20](https://user-images.githubusercontent.com/6025893/74174458-e5260400-4c2b-11ea-9100-7148b7f2e572.png)

this puts them back to just the name :)