### PR TITLE
fix division admin, remove CustomOrganisationChoiceField

### DIFF
--- a/every_election/apps/elections/admin.py
+++ b/every_election/apps/elections/admin.py
@@ -5,8 +5,6 @@ from django.contrib import admin
 from django.forms.widgets import Textarea
 from django_markdown.admin import MarkdownModelAdmin
 from .models import ElectedRole, Election, Explanation, MetaData, ModerationHistory
-from organisations.views.admin.common import CustomOrganisationChoiceField
-from organisations.models import Organisation
 
 
 class ElectionAdmin(admin.ModelAdmin):
@@ -71,8 +69,6 @@ class MetaDataAdmin(admin.ModelAdmin):
 
 
 class ElectedRoleAdminForm(forms.ModelForm):
-    organisation = CustomOrganisationChoiceField(queryset=Organisation.objects.all())
-
     class Meta:
         model = ElectedRole
         fields = "__all__"

--- a/every_election/apps/organisations/views/admin/common.py
+++ b/every_election/apps/organisations/views/admin/common.py
@@ -1,8 +1,0 @@
-from django import forms
-
-
-class CustomOrganisationChoiceField(forms.ModelChoiceField):
-    def label_from_instance(self, obj):
-        return "{name} ({start} - {end})".format(
-            name=obj.name, start=obj.start_date, end=obj.end_date
-        )

--- a/every_election/apps/organisations/views/admin/division_problem.py
+++ b/every_election/apps/organisations/views/admin/division_problem.py
@@ -1,12 +1,9 @@
 from django import forms
 from django.contrib import admin
-from organisations.models import DivisionProblem, Organisation
-from .common import CustomOrganisationChoiceField
+from organisations.models import DivisionProblem
 
 
 class DivisionProblemForm(forms.ModelForm):
-    organisation = CustomOrganisationChoiceField(queryset=Organisation.objects.all())
-
     class Meta:
         model = DivisionProblem
         fields = "__all__"

--- a/every_election/apps/organisations/views/admin/organisation_division.py
+++ b/every_election/apps/organisations/views/admin/organisation_division.py
@@ -34,8 +34,6 @@ class TempIdFilter(admin.SimpleListFilter):
 
 
 class OrganisationDivisionAdminForm(forms.ModelForm):
-    organisation = CustomOrganisationChoiceField(queryset=Organisation.objects.all())
-
     class Meta:
         model = OrganisationDivision
         fields = "__all__"

--- a/every_election/apps/organisations/views/admin/organisation_division.py
+++ b/every_election/apps/organisations/views/admin/organisation_division.py
@@ -1,8 +1,7 @@
 from django.contrib import admin
 from django import forms
 from datetime import datetime
-from organisations.models import Organisation, OrganisationDivision
-from .common import CustomOrganisationChoiceField
+from organisations.models import OrganisationDivision
 
 
 class CurrentDivisionFilter(admin.SimpleListFilter):

--- a/every_election/apps/organisations/views/admin/organisation_divisionset.py
+++ b/every_election/apps/organisations/views/admin/organisation_divisionset.py
@@ -1,12 +1,9 @@
 from django.contrib import admin
 from django import forms
-from organisations.models import Organisation, OrganisationDivisionSet
-from .common import CustomOrganisationChoiceField
+from organisations.models import OrganisationDivisionSet
 
 
 class OrganisationDivisionSetAdminForm(forms.ModelForm):
-    organisation = CustomOrganisationChoiceField(queryset=Organisation.objects.all())
-
     class Meta:
         model = OrganisationDivisionSet
         fields = "__all__"

--- a/every_election/apps/organisations/views/admin/organisation_geography.py
+++ b/every_election/apps/organisations/views/admin/organisation_geography.py
@@ -1,12 +1,9 @@
 from django.contrib import admin
 from django import forms
-from organisations.models import Organisation, OrganisationGeography
-from .common import CustomOrganisationChoiceField
+from organisations.models import OrganisationGeography
 
 
 class OrganisationGeographyAdminForm(forms.ModelForm):
-    organisation = CustomOrganisationChoiceField(queryset=Organisation.objects.all())
-
     class Meta:
         model = OrganisationGeography
         fields = "__all__"

--- a/every_election/apps/organisations/views/admin/organisation_geography_problem.py
+++ b/every_election/apps/organisations/views/admin/organisation_geography_problem.py
@@ -1,12 +1,9 @@
 from django import forms
 from django.contrib import admin
-from organisations.models import Organisation, OrganisationGeographyProblem
-from .common import CustomOrganisationChoiceField
+from organisations.models import OrganisationGeographyProblem
 
 
 class OrganisationGeographyProblemAdminForm(forms.ModelForm):
-    organisation = CustomOrganisationChoiceField(queryset=Organisation.objects.all())
-
     class Meta:
         model = OrganisationGeographyProblem
         fields = "__all__"


### PR DESCRIPTION
Couple of follow-up from PRs #661 and #664 :

When we removed the organisation FK, we forgot to remove the custom choice field so the edit division form in admin was failing to validate because hadn't filled in a form field which has no corresponding DB column.

..but then #664 means that we don't actually need `CustomOrganisationChoiceField` at all because the default behaviour of `ChoiceField` (which uses `str()`)now does a better version of this anyway, so I just completely removed it.