### PR TITLE
Use centroid for example postcode distance calc

### DIFF
--- a/every_election/apps/elections/models.py
+++ b/every_election/apps/elections/models.py
@@ -271,7 +271,9 @@ class Election(models.Model):
             return (
                 Onspd.objects.filter(location__within=self.geography.geography)
                 .filter(location__dwithin=(self.geography.geography.centroid, 0.08))
-                .annotate(distance=Distance("location", self.geography.geography))
+                .annotate(
+                    distance=Distance("location", self.geography.geography.centroid)
+                )
                 .order_by("distance")
                 .first()
             )


### PR DESCRIPTION
This makes performance issues described in #933 bit better - page load for `/elections/gla.a.2021-05-06/` comes down from ~40s to under 10s locally. I think it also was the intended behaviour, before the distance annotation was just '0.0' for all `Onspd` points inside the `OrganisationGeography` because postgis just takes distance as the shortest distance between two geoms. 

It isn't the _right_ fix, but I couldn't get that to work (I've stuck it in the issue for further discussion). 
