### PR TITLE
Check Division when setting seats_contested

### DIFF
--- a/every_election/apps/elections/utils.py
+++ b/every_election/apps/elections/utils.py
@@ -228,7 +228,10 @@ class ElectionBuilder:
             return 1
 
         if self.election_type.election_type != "local":
-            return 1
+            if self.division and self.division.seats_total:
+                return self.division.seats_total
+            else:
+                return 1
 
         """
         If this is an all-up local election, we can fairly safely


### PR DESCRIPTION
Hopefully this doesn't create new ways of being wrong, while making us right more of the time...
It definitely doesn't completely fix the issue. Outstanding is what to do with at large constituencies (#954) and the all up tickbox for locals described in the `ToDo`.