### PR TITLE
Add seats contested for election groups

### DIFF
--- a/every_election/apps/elections/templates/elections/election_summary.html
+++ b/every_election/apps/elections/templates/elections/election_summary.html
@@ -39,6 +39,9 @@
       <dt>Total Seats</dt><dd>{{ object.seats_total }}</dd>
       <dt>Seats Contested</dt><dd>{{ object.seats_contested }}</dd>
     {% endif %}
+    {% if object.group_type %}
+      <dt>Seats Up</dt><dd>{{ object.group_seats_contested }}</dd>
+    {% endif %}
 
     {% if document %}
       {% include './official_document.html' with document=document type=document_type only %}

--- a/every_election/apps/elections/tests/base_tests.py
+++ b/every_election/apps/elections/tests/base_tests.py
@@ -70,6 +70,31 @@ class BaseElectionCreatorMixIn:
             "date": self.date,
         }
 
+        self.testshire_org = Organisation.objects.create(
+            official_identifier="TEST1SHIRE",
+            organisation_type="local-authority",
+            official_name="Testshire County Council",
+            slug="testshire",
+            territory_code="ENG",
+            election_name="Testshire County Council local elections",
+            start_date=date(2016, 10, 1),
+        )
+        ElectedRole.objects.create(
+            election_type=self.election_type1,
+            organisation=self.testshire_org,
+            elected_title="Local Councillor",
+            elected_role_name="Councillor for Testshire Council",
+        )
+        self.testshire_div_set = OrganisationDivisionSetFactory(
+            organisation=self.testshire_org
+        )
+        self.testshire_div = OrganisationDivisionFactory(
+            divisionset=self.testshire_div_set,
+            name="Testshire Div 1",
+            slug="testshire-div",
+            seats_total=3,
+        )
+
     def make_div_id(self, org=None, div=None, subtype=None):
         if not org:
             org = self.org1


### PR DESCRIPTION
![seats_up_locals](https://user-images.githubusercontent.com/20044500/106263376-3011a080-621c-11eb-8175-7b97307fcbab.png)

This is a bit 'nobody asked for it' except, that @pmk01 sort of did, just not for it to be on the website. ~It makes page load for `/elections/local.2021-05-06/` really slow, which is reason enough not to merge - if we did want it the perhaps hiding it behind a button or `if user.is_staff` would be helpful.~ Doesn't seem to add much if anything to page load now. 

The main gains to this sort of thing seem to me:
- easy reporting for tweets and blogs 
- indicating possibility of 'out by one' errors when these sorts of numbers get compared to lists compiled by others. 


It made me think about what other numbers it would be nice to have exposed easily on EE, however that's probably a conversation for how to make the frontend of EE more wieldly in general.  