### PR TITLE
Add election timetable to Election pages

### DIFF
--- a/every_election/apps/elections/models.py
+++ b/every_election/apps/elections/models.py
@@ -21,6 +21,8 @@ from django.urls import reverse
 from django_extensions.db.models import TimeStampedModel
 from django_markdown.models import MarkdownField
 from storages.backends.s3boto3 import S3Boto3Storage
+from uk_election_timetables.calendars import Country
+from uk_election_timetables.election_ids import from_election_id
 from uk_geo_utils.models import Onspd
 
 from .managers import PublicElectionsManager, PrivateElectionsManager
@@ -279,6 +281,27 @@ class Election(models.Model):
             )
         else:
             return None
+
+    @property
+    def get_timetable(self):
+        country_map = {
+            "WLS": Country.WALES,
+            "ENG": Country.ENGLAND,
+            "NIR": Country.NORTHERN_IRELAND,
+            "SCT": Country.SCOTLAND,
+        }
+        area = self.division or self.organisation
+        if not area:
+            return None
+
+        territory_code = area.territory_code or self.organisation.territory_code
+        if not territory_code:
+            return None
+
+        timetable = from_election_id(
+            self.election_id, country=country_map[territory_code]
+        ).timetable
+        return timetable
 
     def get_id(self):
         if self.election_id:

--- a/every_election/apps/elections/templates/elections/election_detail.html
+++ b/every_election/apps/elections/templates/elections/election_detail.html
@@ -35,7 +35,27 @@
             {% endfor %}
             </ul>
         {% endif %}
-        {% if object.get_example_postcode %}
+
+      {% if object.get_timetable %}
+      <h3>Timetable</h3>
+      <table>
+        <thead>
+          <th>Event</th>
+          <th>Date</th>
+        </thead>
+        <tbody>
+          {% for row in object.get_timetable %}
+          <tr>
+          <td>{{ row.label }}</td>
+          <td>{{ row.date }}</td>
+          </tr>
+          {% endfor %}
+
+        </tbody>
+      </table>
+      {% endif %}
+
+      {% if object.get_example_postcode %}
         <h3>Example postcode</h3>
         <p>{{ object.get_example_postcode.pcds }}</p>
         <ul>

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,6 +25,7 @@ six==1.15.0
 sqlparse==0.4.1
 uk-election-ids==0.3.0
 uk-geo-utils==0.10.2
+uk-election-timetables==2.1.1
 
 django-pipeline>=1.6.8,<3.0
 


### PR DESCRIPTION
A quick implementation of the new `.timetable` method of `uk-election-timetables`.

![Screenshot from 2021-02-11 11-11-07](https://user-images.githubusercontent.com/242329/107629383-f0a27580-6c59-11eb-9c98-81b47e6b7fc0.png)
