### PR TITLE
Feature/admin actions

### DIFF
--- a/every_election/apps/elections/admin.py
+++ b/every_election/apps/elections/admin.py
@@ -7,6 +7,27 @@ from django_markdown.admin import MarkdownModelAdmin
 from .models import ElectedRole, Election, Explanation, MetaData, ModerationHistory
 
 
+def mark_current(modeladmin, request, queryset):
+    queryset.update(current=True)
+
+
+mark_current.short_description = "Mark selected elections as 'current'"
+
+
+def mark_not_current(modeladmin, request, queryset):
+    queryset.update(current=False)
+
+
+mark_not_current.short_description = "Mark selected elections as not 'current'"
+
+
+def unset_current(modeladmin, request, queryset):
+    queryset.update(current=None)
+
+
+unset_current.short_description = "Unset 'current' to None"
+
+
 class ElectionAdmin(admin.ModelAdmin):
 
     search_fields = ("election_id",)
@@ -32,6 +53,9 @@ class ElectionAdmin(admin.ModelAdmin):
         "notice",
         "cancellation_notice",
     )
+    list_filter = ["poll_open_date", "current"]
+    list_display = ["election_id", "poll_open_date", "current"]
+    actions = [mark_current, mark_not_current, unset_current]
 
     def get_readonly_fields(self, request, obj=None):
         if obj.identifier_type == "ballot":

--- a/every_election/apps/elections/admin.py
+++ b/every_election/apps/elections/admin.py
@@ -25,7 +25,7 @@ def unset_current(modeladmin, request, queryset):
     queryset.update(current=None)
 
 
-unset_current.short_description = "Unset 'current' to None"
+unset_current.short_description = "Unset 'current'"
 
 
 class ElectionAdmin(admin.ModelAdmin):

--- a/every_election/apps/elections/admin.py
+++ b/every_election/apps/elections/admin.py
@@ -53,9 +53,10 @@ class ElectionAdmin(admin.ModelAdmin):
         "notice",
         "cancellation_notice",
     )
-    list_filter = ["poll_open_date", "current"]
+    list_filter = ["current"]
     list_display = ["election_id", "poll_open_date", "current"]
     actions = [mark_current, mark_not_current, unset_current]
+    date_hierarchy = "poll_open_date"
 
     def get_readonly_fields(self, request, obj=None):
         if obj.identifier_type == "ballot":

--- a/every_election/apps/elections/models.py
+++ b/every_election/apps/elections/models.py
@@ -408,6 +408,13 @@ class Election(models.Model):
             pass
         return None
 
+    def get_admin_url(self):
+        """
+        Build URL to the election in the admin
+        """
+        viewname = f"admin:{self._meta.app_label}_{self._meta.model_name}_change"
+        return reverse(viewname=viewname, kwargs={"object_id": self.pk})
+
     def clean(self):
         if not self.identifier_type == "ballot" and self.cancelled:
             raise ValidationError(

--- a/every_election/apps/elections/templates/elections/election_summary.html
+++ b/every_election/apps/elections/templates/elections/election_summary.html
@@ -46,6 +46,11 @@
     {% if document %}
       {% include './official_document.html' with document=document type=document_type only %}
     {% endif %}
+
+    {% if request.user.is_superuser %}
+      <a href="{{ object.get_admin_url }}" class="button" title="Edit in admin">Edit in admin</a>
+    {% endif %}
+
   </dl>
 
   {% if not object.notice and not object.group.notice and user_can_upload_docs and not object.cancelled %}

--- a/every_election/apps/elections/tests/test_admin.py
+++ b/every_election/apps/elections/tests/test_admin.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock
+
+from elections import admin
+
+from django.test import TestCase
+
+
+class TestAdminActions(TestCase):
+    def test_change_current(self):
+        """
+        Test that when admin actions to update current flag are
+        called, update is called with the relevant value
+        """
+        modeladmin = MagicMock()
+        request = MagicMock()
+        admin_actions = [
+            (admin.mark_current, True),
+            (admin.mark_not_current, False),
+            (admin.unset_current, None),
+        ]
+        for admin_action in admin_actions:
+            action = admin_action[0]
+            is_current = admin_action[1]
+            queryset = MagicMock()
+            with self.subTest(msg=action.short_description):
+                action(modeladmin=modeladmin, request=request, queryset=queryset)
+                queryset.update.assert_called_once_with(current=is_current)

--- a/every_election/apps/elections/tests/test_election_model.py
+++ b/every_election/apps/elections/tests/test_election_model.py
@@ -157,3 +157,10 @@ class TestElectionModel(BaseElectionCreatorMixIn, TestCase):
         self.assertEqual(self.ballot.group_seats_contested, 3)
         self.assertEqual(self.org_group.group_seats_contested, 3)
         self.assertEqual(self.election_group.group_seats_contested, 6)
+
+    def test_get_admin_url(self):
+        election = Election(pk=2021)
+        self.assertEqual(
+            election.get_admin_url(),
+            f"/admin/elections/election/{election.pk}/change/",
+        )


### PR DESCRIPTION
Adds admin actions to:

- Change a queryset of Election objects to be marked as current (`True`)
- Change a queryset of Election objects to be marked not-current (`False`)
- Change a queryset of Election objects to be marked as 'unknown' (`None` in the DB - this is the default)

Although it is less DRY with actions for each rather than having a toggle action between True/False, this felt less likely to cause any potential issues where elections are accidentally marked as current/not current.

Also updates to add filter by poll open date, current - are there any other filters that would be useful here? Perhaps @pmk01 may have some suggestions
Screenshot:
![Screenshot 2021-06-07 at 16 17 40](https://user-images.githubusercontent.com/15347726/121042787-eaf21200-c7ab-11eb-9160-31e3fcdba6aa.png)

Whilst I was making this change, I had a quick check for any other election admin related issues - so decided to include a fix to close #872 

![Screenshot 2021-06-07 at 15 52 14](https://user-images.githubusercontent.com/15347726/121039677-3525c400-c7a9-11eb-8855-f79ef6022b9d.png)
