### PR TITLE
Update election cache after saving new election

### DIFF
--- a/every_election/apps/elections/utils.py
+++ b/every_election/apps/elections/utils.py
@@ -53,7 +53,6 @@ def get_cached_valid_election_types(organisation):
 
 def get_cached_private_elections(date, election_id):
     if not date in CACHE["private_elections"]:
-        print("Called")
         qs = Election.private_objects.filter(poll_open_date=date)
         CACHE["private_elections"][date] = {e.election_id: e for e in qs}
     return CACHE["private_elections"][date].get(election_id)
@@ -76,6 +75,10 @@ def get_cached_elected_role(organisation, election_type):
 
 
 class ElectionBuilder:
+    def __del__(self):
+        for key in CACHE:
+            CACHE[key] = {}
+
     def __init__(self, election_type, date):
 
         # init params


### PR DESCRIPTION
This isn't an ideal solution, but the problem is a little more complex
to refactor than I'd anticipated.

Before the May 2021 local elections we were getting timeouts when adding
new elections. This was because the ID Builder performed an huge amount
of duplicate lookups.

As a quick fix, I added a cache, however the way I implemented it was to
set up a global, in memory cache. This will be cleared as gunicorn
workers cycle out, but it won't be cleared for each IdBuilder instance.

The result of this is that we can have a stale cache hanging around for
too long, and in turn this causes a false negative look up, meaning we
end up trying to create a duplicate election, and in the end causing a
500 due to a postgres duplicate key.

The real solution is to invalidate the cache after all the IDs have been
created. This solution invalidates the cache after each creator instance
is closed down. It's not clear when exactly this it, but it's sure to be
once per organisation.

This will cause more queries than needed, but will ensure that the bug
isn't hit.

Fixes #1162