### PR TITLE
Bump jsmin to 3.0.0

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,5 +2,5 @@
 
 ec2_tag_conditional==0.1.2
 gunicorn==20.1.0
-jsmin==2.2.2
+jsmin==3.0.0
 raven==6.10.0


### PR DESCRIPTION
Jsmin 2.2.2 was failing to build. For more details see https://github.com/tikitu/jsmin/issues/33