### PR TITLE
Fix ALDC Scraper

### DIFF
--- a/every_election/apps/election_snooper/snoopers/aldc.py
+++ b/every_election/apps/election_snooper/snoopers/aldc.py
@@ -13,11 +13,10 @@ class ALDCScraper(BaseSnooper):
         print(url)
         soup = self.get_soup(url)
         for tile in soup.find_all("article"):
-
             title = tile.find("h2").text.strip()
             detail_url = url + "#" + tile["id"]
             date = tile.find("date").text.strip()
-            content = tile.find("div", {"class": "c-editor"}).find_all("p")
+            content = tile.find("div", {"class": ""}).find_all("p")
 
             if content and content[0].text.lower().count("cause") == 1:
                 seat_control, cause = content[0].text.lower().split("cause")


### PR DESCRIPTION
The div wrapping the election info tags no longer has any css class.
This seems to work for what is currently on the homepage.