### PR TITLE
Add 'GBN' to country_map in Election.get_timetable

### DIFF
--- a/every_election/apps/elections/models.py
+++ b/every_election/apps/elections/models.py
@@ -324,6 +324,7 @@ class Election(TimeStampedModel):
             "ENG": Country.ENGLAND,
             "NIR": Country.NORTHERN_IRELAND,
             "SCT": Country.SCOTLAND,
+            "GBN": None,
         }
         area = self.division or self.organisation
         if not area:


### PR DESCRIPTION
The from_election_id function from election timetables doesn't need a
country code. This is because 'country' in this case is scoped to the
nations that make up Great Britain. Obvs the House of Commons covers all
of these, and correctly has GBN as it's territory code. In this case we
can just pass None and the election timetables library will take care of
it based only on the election id.

Closes #1282