### PR TITLE
SPIKE: filter by local authority area

### DIFF
--- a/every_election/apps/api/filters.py
+++ b/every_election/apps/api/filters.py
@@ -1,9 +1,63 @@
 import django_filters
+from django.core.exceptions import ValidationError
+from django.db.models import Q
 
 from elections.models import Election
+from organisations.models import OrganisationGeography
 
 
 class ElectionFilter(django_filters.FilterSet):
+    def election_intersects_local_authority_filter(self, queryset, name, value):
+
+        og_qs = OrganisationGeography.objects.filter(
+            organisation__official_identifier=value,
+            organisation__organisation_type="local-authority",
+        ).select_related("organisation")
+
+        if not og_qs.exists():
+            raise ValidationError(
+                """Only local authorities supported""",
+                code="invalid",
+            )
+
+        if "poll_open_date" in self.data and self.data["poll_open_date"]:
+            og_qs = og_qs.filter(
+                Q(start_date__lte=self.data["poll_open_date"]) | Q(start_date=None)
+            )
+
+        if (
+            "organisation_start_date" in self.data
+            and self.data["organisation_start_date"]
+        ):
+            og_qs = og_qs.filter(
+                Q(start_date__lte=self.data["organisation_start_date"])
+                | Q(start_date=None)
+            )
+
+        try:
+            og = og_qs.get()
+        except OrganisationGeography.MultipleObjectsReturned:
+            raise ValidationError(
+                """Organisation has more than one geography,
+                please specify a `poll_open_date` or organisation_start_date""",
+                code="invalid",
+            )
+        # Large geographies don't perform well with the __relate filter.
+        # If the area of the organisation is larger than "2", use a different
+        # method. "2" is less than the highlands but greater than North
+        # Yorkshire County Council.
+        if og.geography.area < 2:
+            # See https://en.wikipedia.org/wiki/DE-9IM for magic string
+            magic_string = "T*****T**"
+            return queryset.filter(
+                division_geography__geography__relate=(
+                    og_qs.get().geography,
+                    magic_string,
+                )
+            )
+        return queryset.filter(
+            division_geography__geography__bboverlaps=og_qs.get().geography
+        )
 
     organisation_identifier = django_filters.CharFilter(
         field_name="organisation__official_identifier",
@@ -12,6 +66,10 @@ class ElectionFilter(django_filters.FilterSet):
     organisation_type = django_filters.CharFilter(
         field_name="organisation__organisation_type",
         lookup_expr="exact",
+    )
+    election_intersects_local_authority = django_filters.CharFilter(
+        label="Election intersects local authority",
+        method="election_intersects_local_authority_filter",
     )
     organisation_start_date = django_filters.DateFilter(
         field_name="organisation__start_date",

--- a/every_election/apps/api/filters.py
+++ b/every_election/apps/api/filters.py
@@ -48,15 +48,24 @@ class ElectionFilter(django_filters.FilterSet):
         # Yorkshire County Council.
         if og.geography.area < 2:
             # See https://en.wikipedia.org/wiki/DE-9IM for magic string
-            magic_string = "T*****T**"
+            magic_string = "T********"
             return queryset.filter(
-                division_geography__geography__relate=(
-                    og_qs.get().geography,
-                    magic_string,
+                Q(
+                    division_geography__geography__relate=(
+                        og_qs.get().geography,
+                        magic_string,
+                    )
+                )
+                | Q(
+                    organisation_geography__geography__relate=(
+                        og_qs.get().geography,
+                        magic_string,
+                    )
                 )
             )
         return queryset.filter(
-            division_geography__geography__bboverlaps=og_qs.get().geography
+            Q(division_geography__geography__bboverlaps=og_qs.get().geography)
+            | Q(organisation_geography__geography__bboverlaps=og_qs.get().geography)
         )
 
     organisation_identifier = django_filters.CharFilter(


### PR DESCRIPTION
Endpoint for filtering ballots by local authority geographies.

I'm not sure about the magic string. Some initial testing and getting confused by the wikipedia page suggests it's current, but it's very much not in my head properly.

I tested the Highlands. It's really slow. So I moved to using `bboverlaps` as a _really_ rough proxy for the same thing, without all the fiddly bits. This only kicks in above a given area,but I don't know what the unit is!

It's going to give more false positives, but I think it's literally just the Highlands that have the problem. I also think that they'll mostly have all-up-Scotland elections, so it's not really going to matter.