### PR TITLE
Use https to for git repos in requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -32,5 +32,5 @@ django-pipeline>=1.6.8,<3.0
 importlib-metadata==4.8.1
 
 git+https://github.com/mysociety/django-pipeline-csscompressor
-git+git://github.com/DemocracyClub/dc_base_theme.git@83ffc6de1ca3b81f1866f52a5c6c5bfb552ea77d
+git+https://github.com/DemocracyClub/dc_base_theme.git@83ffc6de1ca3b81f1866f52a5c6c5bfb552ea77d
 git+https://github.com/DemocracyClub/dc_signup_form.git@2.1.0


### PR DESCRIPTION
Github doesn't use unencrypted git protocol anymore.

More info: https://github.blog/2021-09-01-improving-git-protocol-security-github/