### PR TITLE
Ordering on api

### DIFF
--- a/every_election/apps/api/filters.py
+++ b/every_election/apps/api/filters.py
@@ -1,6 +1,7 @@
 import django_filters
 from django.core.exceptions import ValidationError
 from django.db.models import Q
+from django.forms import Select
 from django.utils.timezone import now
 
 from elections.models import Election
@@ -55,6 +56,29 @@ class ElectionFilter(django_filters.FilterSet):
             Q(division_geography__geography__bboverlaps=og_qs.get().geography)
             | Q(organisation_geography__geography__bboverlaps=og_qs.get().geography)
         )
+
+    def filter_by_order(self, queryset, name, value):
+        if value == "recent":
+            return queryset.order_by("-poll_open_date")
+        elif value == "older":
+            return queryset.order_by("poll_open_date")
+
+        return queryset
+
+    CHOICES = (
+        ("recent", "Show recent poll dates first"),
+        ("older", "Show oldest poll dates first"),
+    )
+
+    ordering = django_filters.ChoiceFilter(
+        label="Ordering",
+        choices=CHOICES,
+        method="filter_by_order",
+        empty_label=None,
+        widget=Select(attrs={"autocomplete": "off"}),
+    )
+
+    default_ordering = "older"
 
     organisation_identifier = django_filters.CharFilter(
         field_name="organisation__official_identifier",

--- a/every_election/apps/api/tests/test_api_election_endpoint.py
+++ b/every_election/apps/api/tests/test_api_election_endpoint.py
@@ -553,3 +553,28 @@ class TestElectionAPIQueries(APITestCase):
             ["overlaps", "same", "contains", "within"],
             [e["election_title"] for e in data["results"]],
         )
+
+    def test_ordering_filter(self):
+        ElectionWithStatusFactory(election_title="old", poll_open_date="2017-03-23")
+        ElectionWithStatusFactory(election_title="middle", poll_open_date="2017-03-24")
+        ElectionWithStatusFactory(election_title="recent", poll_open_date="2017-03-25")
+
+        resp = self.client.get(
+            "/api/elections/?ordering=recent",
+            content_type="application/json",
+        )
+        data = resp.json()
+        self.assertListEqual(
+            ["recent", "middle", "old"],
+            [e["election_title"] for e in data["results"]],
+        )
+
+        resp = self.client.get(
+            "/api/elections/?ordering=older",
+            content_type="application/json",
+        )
+        data = resp.json()
+        self.assertListEqual(
+            ["old", "middle", "recent"],
+            [e["election_title"] for e in data["results"]],
+        )


### PR DESCRIPTION
Hi!

Was exploring some parts of the API and noticed that there didn't seem to be an option to do any ordering within the API itself, so i've added this!

At the moment, just a way to order based on when the poll date is - take a look at the filters in http://127.0.0.1:8000/api/elections/ and you should see the ordering. I couldn't find an easy way to get enough test data in so I may have missed some edge cases - but all seems perfectly fine! I've added a test to cover this new addition.

Any questions, let me know!