### PR TITLE
Add help text to metadata form

### DIFF
--- a/every_election/apps/elections/admin.py
+++ b/every_election/apps/elections/admin.py
@@ -123,6 +123,9 @@ class MetaDataAdmin(admin.ModelAdmin):
     def get_form(self, *args, **kwargs):
         self.form = deepcopy(self.form)
         form = super().get_form(*args, **kwargs)
+        form.base_fields[
+            "data"
+        ].help_text = "Meta Data should only be added to an election in exceptional circumstances and should not repeat existing template text."
         form.base_fields["data"].widget = JSONEditor()
         return form
 


### PR DESCRIPTION
Ref https://github.com/DemocracyClub/EveryElection/issues/1685

Adds help text to the meta data form in admin to help prevent duplicated text: "Meta Data should only be added to an election in exceptional circumstances and should not repeat existing template text."

<img width="1464" alt="Screenshot 2023-01-03 at 12 10 08 PM" src="https://user-images.githubusercontent.com/7017118/210354925-6293a7cd-7c19-47e5-b3dc-08c011f6f7f9.png">
