### PR TITLE
Bump uk-election-timetables to 2.4.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,7 @@ retry2==0.9.5
 six==1.16.0
 sqlparse==0.4.3
 uk-election-ids==0.6.1
-uk-election-timetables==2.3.0
+uk-election-timetables==2.4.0
 uk-geo-utils==0.11.0
 
 django-pipeline==2.0.8


### PR DESCRIPTION
This should resolve the issue Peter highlighted with RTV deadlines as the current version (2.3.0) does not include the additional bank holiday for the 8th May coronation. 