### PR TITLE
Fix error formatting

### DIFF
--- a/every_election/apps/elections/templates/id_creator/id_creator_base.html
+++ b/every_election/apps/elections/templates/id_creator/id_creator_base.html
@@ -15,7 +15,6 @@
                     {{ form|dc_form }}
                 {% endfor %}
             {% else %}
-                {{ wizard.form.errors }}
                 {{ wizard.form|dc_form }}
             {% endif %}
         {% endblock form_content %}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -32,9 +32,10 @@ importlib-metadata==6.0.0
 
 git+https://github.com/DemocracyClub/dc_signup_form.git@2.1.3
 git+https://github.com/DemocracyClub/design-system.git@0.2.4
-git+https://github.com/DemocracyClub/dc_django_utils.git@2.1.2
+git+https://github.com/DemocracyClub/dc_django_utils.git@2.1.3
 
 django-dotenv==1.4.2
 
 
 setuptools>=65.5.1
+

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -32,7 +32,7 @@ importlib-metadata==6.0.0
 
 git+https://github.com/DemocracyClub/dc_signup_form.git@2.1.3
 git+https://github.com/DemocracyClub/design-system.git@0.2.4
-git+https://github.com/DemocracyClub/dc_django_utils.git@2.1.3
+git+https://github.com/DemocracyClub/dc_django_utils.git@2.1.4
 
 django-dotenv==1.4.2
 


### PR DESCRIPTION
This work addressed broken duplicate error messages and fixes error message formatting for the field date in the ID creator as well as the user login. 

Before
<img width="1025" alt="Screenshot 2023-02-15 at 2 43 01 PM" src="https://user-images.githubusercontent.com/7017118/219171877-0fee61a6-3078-4a74-b4c5-0dffdf4bc21f.png">
After
<img width="1039" alt="Screenshot 2023-02-15 at 2 45 43 PM" src="https://user-images.githubusercontent.com/7017118/219171887-dbe689bd-36f1-4196-a91c-5ade55f208d2.png">


Before
<img width="977" alt="Screenshot 2023-02-15 at 9 19 40 PM" src="https://user-images.githubusercontent.com/7017118/219172246-ad9d2f99-d1a3-43c9-9614-97be78e06069.png">

After
<img width="1056" alt="Screenshot 2023-02-15 at 9 18 22 PM" src="https://user-images.githubusercontent.com/7017118/219172218-cb843d98-ec7f-4715-9197-799fe23fe813.png">