### PR TITLE
Temp turn off election radar

### DIFF
--- a/cdk_stacks/stacks/command_runner.py
+++ b/cdk_stacks/stacks/command_runner.py
@@ -54,11 +54,11 @@ class EEOncePerTagCommandRunner(Stack):
             )
 
             # New elections
-            self.add_job(
-                "snoop",
-                "cron(30 * * * ? *)",
-                "output-on-error ee-manage-py-command snoop",
-            )
+            # self.add_job(
+            #     "snoop",
+            #     "cron(30 * * * ? *)",
+            #     "output-on-error ee-manage-py-command snoop",
+            # )
 
             # Generate map layers and sync to S3
             self.add_job(


### PR DESCRIPTION
Closes https://trello.com/c/NUUh44GP/3307-turn-off-election-radar

EveryElection scrapes council websites for new notices of election. When we know about scheduled elections the scraper is a) pointless and b) will spam slack with notifications.


![Screenshot 2023-03-14 at 9 58 00 AM](https://user-images.githubusercontent.com/7017118/224965091-1098428d-168c-4fb1-a73c-b04f6abf75d4.png)


```[tasklist]
### PR Checklist
<!-- Not all the items in this list will be relevant for every repo -->
<!-- When creating a Pull Request please delete items as necessary, leaving those that are relevant.  -->

Check off items once the PR addresses them.

- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Note what card in Trello this work relates to
- [x] Update dev handbook
- [x] Update documentation https://github.com/DemocracyClub/EveryElection/wiki/Election-checklist
```
