### PR TITLE
Add requires_voter_id to election serializer

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -95,3 +95,7 @@ To run a project-wide reformat, run:
 ```commandline
 black .
 ```
+
+## Development Notes
+
+- If adding any new fields to EveryElection, you may also need to add them to the EE API app within this project.

--- a/every_election/apps/api/serializers.py
+++ b/every_election/apps/api/serializers.py
@@ -157,6 +157,7 @@ election_fields = (
     "seats_contested",
     "division",
     "voting_system",
+    "requires_voter_id",
     "current",
     "explanation",
     "metadata",

--- a/every_election/apps/api/tests/test_api_election_endpoint.py
+++ b/every_election/apps/api/tests/test_api_election_endpoint.py
@@ -465,6 +465,7 @@ class TestElectionAPIQueries(APITestCase):
             "cancelled": false,
             "replaces": null,
             "replaced_by": null,
+            "requires_voter_id": null,
             "tags": {"FOO":{"bar":"baz"}},
             "created": "2017-01-23T00:00:00Z",
             "modified": "2017-01-23T00:00:00Z"


### PR DESCRIPTION
This was missed in the big voter ID update and is required to feed information through to WDIV. 

I tested this by setting `EE_BASE` in WDIV to point at localhost:5000, running both EE (on 5000) and WDIV and then using pdb in WDIV to manually inspect the payload coming back from the EE api. Probably a bit long-winded to follow for this very minor change but I don't want to discourage other people testing it!

```[tasklist]
### PR Checklist
- [x] Instructions for how reviewers can test the code locally
- [x] Tests have been added and/or updated
- [x] Update any documentation
```
