### PR TITLE
Fix quotes on nuts tag ssm command

### DIFF
--- a/cdk_stacks/stacks/command_runner.py
+++ b/cdk_stacks/stacks/command_runner.py
@@ -71,7 +71,7 @@ class EEOncePerTagCommandRunner(Stack):
             self.add_job(
                 "add_nuts1_tags",
                 "cron(15 2 * * ? *)",
-                """output-on-error ee-manage-py-command add_tags -u "https://ons-cache.s3.eu-west-1.amazonaws.com/NUTS_Level_1_(January_2018)_Boundaries.geojson" --fields ''{"NUTS118NM": "value", "NUTS118CD": "key"}'' --tag-name NUTS1""",
+                """output-on-error ee-manage-py-command add_tags -u "https://ons-cache.s3.eu-west-1.amazonaws.com/NUTS_Level_1_(January_2018)_Boundaries.geojson" --fields '{"NUTS118NM": "value", "NUTS118CD": "key"}' --tag-name NUTS1""",
             )
 
     def add_job(


### PR DESCRIPTION
This should deploy on Dev, and can then be run from console. 
However I've tried out the command in prod so am optimistic.