### PR TITLE
Set election radar to run every day

### DIFF
--- a/deployscripts/crontab
+++ b/deployscripts/crontab
@@ -4,3 +4,4 @@
 0 2 * * * every_election cd /var/www/every_election/repo && ./serverscripts/rebuild_local_db.sh
 30 2 * * * every_election cd /var/www/every_election/repo && ./serverscripts/add_nuts1.sh
 0 1 * * * ee-manage-py-command dumpdata elections election_snooper --indent 4 -o /var/www/every_election/repo/every_election/data/elections.json
+0 0 * * * ee-manage-py-command snoop

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ glob2==0.7
 markdown==3.4.3
 psutil==5.9.4
 psycopg2-binary==2.9.6
-requests==2.28.2
+requests==2.31.0
 retry2==0.9.5
 six==1.16.0
 sqlparse==0.4.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,7 +21,7 @@ psycopg2-binary==2.9.6
 requests==2.31.0
 retry2==0.9.5
 six==1.16.0
-sqlparse==0.4.3
+sqlparse==0.4.4
 uk-election-ids==0.7.2
 uk-election-timetables==2.4.0
 uk-geo-utils==0.11.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.12.1
 boto3==1.26.56
-Django==4.1.7
+Django==4.1.10
 django-basicauth==0.5.3
 django-cors-headers==3.14.0
 django-extensions==3.2.1


### PR DESCRIPTION
Ref https://trello.com/c/LzXzoxbe/3391-post-election-tasks

This change adds the management command for election snooper to run every day at 12pm. 

I've had to address some security vulnerabilities to get to a passing state in CI; a more comprehensive set up upgrades will come shortly with https://trello.com/c/gI6suc2g/3416-ee-django-42-upgrades