### PR TITLE
Hotfix/specify env in slack posts

### DIFF
--- a/every_election/apps/election_snooper/helpers.py
+++ b/every_election/apps/election_snooper/helpers.py
@@ -1,4 +1,5 @@
 import json
+import os
 import textwrap
 import warnings
 
@@ -8,14 +9,26 @@ import requests
 
 
 def post_to_slack(message):
-    if not hasattr(settings, "SLACK_WEBHOOK_URL"):
+    env = os.getenv("SERVER_ENVIRONMENT", getattr(settings, "SERVER_ENVIRONMENT", None))
+    if env in ["test", "development", "staging"]:
+        prefix = "TEST for {} environment: ".format(env)
+        message = prefix + message
+    url = settings.SLACK_WEBHOOK_URL
+
+    if not hasattr(settings, "SLACK_WEBHOOK_URL") and env == "production":
         warnings.warn("settings.SLACK_WEBHOOK_URL is not set")
         return
+    if not hasattr(settings, "SLACK_WEBHOOK_URL") and env in [
+        "test",
+        "development",
+        "staging",
+    ]:
+        print("SLACK_WEBHOOK_URL is not set")
 
     payload = {
         "icon_emoji": ":satellite_antenna:",
         "username": "Election Radar",
         "text": textwrap.dedent(message),
     }
-    url = settings.SLACK_WEBHOOK_URL
+
     requests.post(url, json.dumps(payload), timeout=2)

--- a/every_election/apps/election_snooper/snoopers/base.py
+++ b/every_election/apps/election_snooper/snoopers/base.py
@@ -1,4 +1,6 @@
+import os
 from bs4 import BeautifulSoup
+from django.conf import settings
 import requests
 from election_snooper.helpers import post_to_slack
 

--- a/every_election/settings/local.example.py
+++ b/every_election/settings/local.example.py
@@ -12,6 +12,11 @@ DATABASES = {
 # google custom search API key
 GCS_API_KEY = ""
 
+# don't use the real url in dev or staging
+# there is a webhook url for each environment, so
+# we can test the slack integration
+SLACK_WEBHOOK_URL = ""
+
 # AWS credentials
 AWS_ACCESS_KEY_ID = ""
 AWS_SECRET_ACCESS_KEY = ""


### PR DESCRIPTION
Ref https://github.com/DemocracyClub/EveryElection/issues/1869

This change concatenates a test message to the core message for any notification posted to Slack. It also posts test messages from `dev` or `staging` to a new webhook url in `#bots`.

I've had to address some security vulnerabilities to get to a passing state in CI; a more comprehensive set up upgrades will come shortly with https://trello.com/c/gI6suc2g/3416-ee-django-42-upgrades

To test, make sure you have `SERVER_ENVIRONMENT` and `TEST_SLACK_WEBHOOK_URL` set in your `local.py` and create an election. Message me for the webhook url to add to settings. A slack post similar to below should appear in #bots.

<img width="1151" alt="Screenshot 2023-07-18 at 3 50 57 PM" src="https://github.com/DemocracyClub/EveryElection/assets/7017118/bc15aff4-0b6f-4388-9d3c-f162e72ffa01">
