### PR TITLE
Bump uk-election-timetables from 2.4.0 to 2.4.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,7 +22,7 @@ retry2==0.9.5
 six==1.16.0
 sqlparse==0.4.4
 uk-election-ids==0.7.3
-uk-election-timetables==2.4.0
+uk-election-timetables==2.4.1
 uk-geo-utils==0.12.0
 
 django-pipeline==2.1.0


### PR DESCRIPTION
As title.

New patch version of UK Election Timetables has corrected postal vote deadline dates for NI.