### PR TITLE
Add cancellation reason to /elections

### DIFF
--- a/every_election/apps/api/serializers.py
+++ b/every_election/apps/api/serializers.py
@@ -162,6 +162,7 @@ election_fields = (
     "metadata",
     "deleted",
     "cancelled",
+    "cancellation_reason",
     "replaces",
     "replaced_by",
     "tags",

--- a/every_election/apps/api/tests/test_api_election_endpoint.py
+++ b/every_election/apps/api/tests/test_api_election_endpoint.py
@@ -487,6 +487,7 @@ class TestElectionAPIQueries(APITestCase):
             "metadata": null,
             "deleted": false,
             "cancelled": false,
+            "cancellation_reason": null,
             "replaces": null,
             "replaced_by": null,
             "requires_voter_id": null,


### PR DESCRIPTION
Ref #1972 
[Asana](https://app.asana.com/0/1204880927741389/1205170296632727)

Very straightforward one this. 

To test locally:
- Make sure you're UTD on migrations
- Hit the EE API locally @ `http://localhost:8000/api/elections/`
- Elections returned should have a `cancellation_reason` field - this will currently be null for all elections because no migration has been done yet.

```[tasklist]
### PR Checklist
- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Note what card in Asana this work relates to
- [x] Instructions for how reviewers can test the code locally
- [x] Tests have been added and/or updated
```
