### PR TITLE
Feature/admin panel filtering

### DIFF
--- a/every_election/apps/elections/admin.py
+++ b/every_election/apps/elections/admin.py
@@ -17,6 +17,35 @@ from .models import (
 )
 
 
+class GroupTypeListFilter(admin.SimpleListFilter):
+    """
+    Elections without a group type are considered "ballots".
+    Becuase "ballot" is implied only, this class is used to override
+    the "-" option in the admin panel filters and make it read "ballot".
+    """
+
+    title = "group type"
+    parameter_name = "group_type"
+
+    def lookups(self, request, model_admin):
+        return [
+            ("ballot", "Ballot"),
+            ("election", "Election"),
+            ("organisation", "Organisation"),
+            ("subtype", "Subtype"),
+        ]
+
+    def queryset(self, request, queryset):
+        if self.value() == "ballot":
+            return queryset.filter(
+                group_type=None,
+            )
+
+        return queryset.filter(
+            group_type=self.value(),
+        )
+
+
 def mark_current(modeladmin, request, queryset):
     queryset.update(current=True)
 
@@ -83,7 +112,7 @@ class ElectionAdmin(admin.ModelAdmin):
         "cancellation_notice",
         "current_status",
     )
-    list_filter = ["current", "cancelled", "group_type"]
+    list_filter = ["current", "cancelled", GroupTypeListFilter]
     list_display = [
         "election_id",
         "poll_open_date",

--- a/every_election/apps/elections/admin.py
+++ b/every_election/apps/elections/admin.py
@@ -83,7 +83,7 @@ class ElectionAdmin(admin.ModelAdmin):
         "cancellation_notice",
         "current_status",
     )
-    list_filter = ["current"]
+    list_filter = ["current", "cancelled", "group_type"]
     list_display = [
         "election_id",
         "poll_open_date",


### PR DESCRIPTION
Ref #1939 
[Asana](https://app.asana.com/0/1204880927741389/1205170301994011)

Updated the admin panel filters to include group type and cancelled. 

Because group type is nullable, but null represents a single "ballot", I've added a list filter to override the text. This should make things easier for admin panel users. 

<img width="279" alt="Screenshot 2023-08-11 at 10 55 30" src="https://github.com/DemocracyClub/EveryElection/assets/9531063/e312a020-034b-4953-9052-17d0040a3e97">

To test locally:
- boot up the admin panel and log in
- Go to `Elections`
- Try out the two new filters 

```[tasklist]
### PR Checklist
- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Note what card in Trello this work relates to
- [x] Instructions for how reviewers can test the code locally
- [x] Screenshot of the feature/bug fix (if applicable)
```
