### PR TITLE
Feature/admin panel fieldsets

### DIFF
--- a/every_election/apps/elections/admin.py
+++ b/every_election/apps/elections/admin.py
@@ -88,6 +88,64 @@ soft_delete.short_description = "Soft delete"
 class ElectionAdmin(admin.ModelAdmin):
     search_fields = ("election_id",)
 
+    fieldsets = (
+        (
+            "Election Information",
+            {
+                "fields": (
+                    "election_id",
+                    "election_title",
+                    "group_type",
+                    "group",
+                )
+            },
+        ),
+        (
+            "Ballot Information",
+            {
+                "fields": (
+                    "current",
+                    "cancelled",
+                    "cancellation_reason",
+                    "seats_contested",
+                    "seats_total",
+                    "replaces",
+                    "requires_voter_id",
+                    "voting_system",
+                    "explanation",
+                    "metadata",
+                ),
+            },
+        ),
+        (
+            "Source Information",
+            {
+                "fields": (
+                    "source",
+                    "snooped_election",
+                ),
+            },
+        ),
+        (
+            "Internal Metadata",
+            {
+                "classes": ("collapse",),
+                "fields": (
+                    "tmp_election_id",
+                    "organisation",
+                    "division",
+                    "tags",
+                    "elected_role",
+                    "poll_open_date",
+                    "election_subtype",
+                    "election_type",
+                    "modified",
+                    "created",
+                ),
+            },
+        ),
+    )
+
     def has_add_permission(self, request):
         return False
 


### PR DESCRIPTION
Ref #1972 
[Asana](https://app.asana.com/0/1204880927741389/1205231021592928)

Just a part of the admin panel rejig. This work:
- Splits the fields into sections
- Makes the metadata section collapsible
- Hides the Ballot Information section for any Elections which have a group type (these represent ballots)

This screenshot shows the management page for a non-ballot Election object.
<img width="1157" alt="Screenshot 2023-08-15 at 16 51 58" src="https://github.com/DemocracyClub/EveryElection/assets/9531063/77303086-4b71-4d34-a06e-10a329ee35b9">

This screenshot shows the Ballot Information panel that appears when an election's group type is None.
<img width="1157" alt="Screenshot 2023-08-15 at 16 52 54" src="https://github.com/DemocracyClub/EveryElection/assets/9531063/981e0338-c07d-4344-b503-62453ece7377">

To test locally:
- Open up the admin panel
- Find an election which is a "ballot" group type (there's a new filter for this 😎 )
- This should have the "Ballot Information" section
- Find an election which is any other group type 
- This should not have the "Ballot Information" section

```[tasklist]
### PR Checklist
- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Note what card in Asana this work relates to
- [x] Instructions for how reviewers can test the code locally
- [x] Screenshot of the feature/bug fix (if applicable)
- [x] Added any comments to make new functions clearer
```
