### PR TITLE
Allow longer args in API params

### DIFF
--- a/every_election/apps/api/filters.py
+++ b/every_election/apps/api/filters.py
@@ -77,14 +77,14 @@ class ElectionFilter(django_filters.FilterSet):
         label="Filter elections by their election id using a regular expression",
         field_name="election_id",
         lookup_expr="regex",
-        max_length="20",
+        max_length="200",
     )
     exclude_election_id_regex = django_filters.CharFilter(
         label="Exclude elections by their election id using a regular expression",
         field_name="election_id",
         lookup_expr="regex",
         exclude=True,
-        max_length="20",
+        max_length="200",
     )
     modified = django_filters.IsoDateTimeFilter(
         field_name="modified",


### PR DESCRIPTION
This is needed as election ID regexs are often longer than 20 chars!