### PR TITLE
Feature/boundary review frontend

### DIFF
--- a/every_election/apps/organisations/filters.py
+++ b/every_election/apps/organisations/filters.py
@@ -1,0 +1,83 @@
+from urllib.parse import urlencode
+
+import django_filters
+from django.db.models import BLANK_CHOICE_DASH
+from django.utils.encoding import force_str
+from django.utils.safestring import mark_safe
+from django_filters.widgets import LinkWidget
+
+from .models import OrganisationBoundaryReview, ReviewStatus
+
+
+class DSLinkWidget(LinkWidget):
+    """
+    The LinkWidget doesn't allow iterating over choices in the template layer
+    to change the HTML wrappig the widget.
+
+    This breaks the way that Django *should* work, so we have to subclass
+    and alter the HTML in Python :/
+
+    https://github.com/carltongibson/django-filter/issues/880
+    """
+
+    def render(self, name, value, attrs=None, choices=(), renderer=None):
+        if not hasattr(self, "data"):
+            self.data = {}
+        if value is None:
+            value = ""
+        self.build_attrs(self.attrs, extra_attrs=attrs)
+        output = []
+        options = self.render_options(choices, [value], name)
+        if options:
+            output.append(options)
+        # output.append('</ul>')
+        return mark_safe("\n".join(output))
+
+    def render_option(self, name, selected_choices, option_value, option_label):
+        option_value = force_str(option_value)
+        if option_label == BLANK_CHOICE_DASH[0][1]:
+            option_label = "All"
+        data = self.data.copy()
+        data[name] = option_value
+        selected = data == self.data or option_value in selected_choices
+        try:
+            url = data.urlencode()
+        except AttributeError:
+            url = urlencode(data)
+        return self.option_string() % {
+            "attrs": selected and ' aria-current="true"' or "",
+            "query_string": url,
+            "label": force_str(option_label),
+        }
+
+
+class OrganisationBoundaryReviewFilter(django_filters.FilterSet):
+    def organisation_filter(self, queryset, name, value):
+        """
+        Filter queryset by organisation
+        """
+        return queryset.filter(organisation__common_name__icontains=value)
+
+    def status_filter(self, queryset, name, value):
+        """
+        Filter queryset by status
+        """
+        return queryset.filter(status=value)
+
+    organisation = django_filters.CharFilter(
+        label="organisation",
+        method="organisation_filter",
+    )
+
+    status = django_filters.ChoiceFilter(
+        label="status",
+        widget=DSLinkWidget(),
+        choices=ReviewStatus.choices,
+    )
+
+    class Meta:
+        model = OrganisationBoundaryReview
+        fields = [
+            "status",
+            "organisation",
+        ]

--- a/every_election/apps/organisations/models/__init__.py
+++ b/every_election/apps/organisations/models/__init__.py
@@ -9,6 +9,7 @@ from organisations.models.divisions import (
     OrganisationBoundaryReview,
     OrganisationDivision,
     OrganisationDivisionSet,
+    ReviewStatus,
 )
 from organisations.models.organisations import (
     Organisation,
@@ -28,4 +29,5 @@ __all__ = [
     "DivisionGeography",
     "DivisionGeographySubdivided",
     "OrganisationBoundaryReview",
+    "ReviewStatus",
 ]

--- a/every_election/apps/organisations/models/divisions.py
+++ b/every_election/apps/organisations/models/divisions.py
@@ -277,6 +277,12 @@ class OrganisationBoundaryReview(TimeStampedModel):
         return f"https://{url}"
 
     @property
+    def generic_title(self):
+        if self.legislation_title:
+            return self.legislation_title
+        return f"Boundary review for {self.organisation.common_name} ({self.status})"
+
+    @property
     def can_upload_boundaries(self):
         if self.boundaries_url:
             return True

--- a/every_election/apps/organisations/templates/organisations/organisationboundaryreview_detail.html
+++ b/every_election/apps/organisations/templates/organisations/organisationboundaryreview_detail.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+{% block page_title %}Boundary Review Summary{% endblock page_title %}
+
+{% block content %}
+<div class="ds-card">
+	<div class="ds-card-body">
+		<h1>
+			{{boundary_review_name}}
+		</h1>
+
+		<dl class="ds-descriptions">
+			<div>
+				<dt>Organisation</dt>
+				<dd><a href={{boundary_review.organisation.get_absolute_url}}>{{boundary_review.organisation.name}}</a></dd>
+			</div>
+			<div>
+				<dt>Status</dt>
+				<dd>{{ boundary_review.get_status_display }}</dd>
+			</div>
+			<div>
+				<dt>Consultation</dt>
+				{% if boundary_review.consultation_url %}
+					<dd>Read <a href="{{ boundary_review.consultation_url }}">the consultation</a> for this review</dd>
+				{% else %}
+					<dd>Consultation Link Missing</dd>
+				{% endif %}
+				</div> 
+				<div>
+					<dt>Legislation</dt>
+				{% if boundary_review.legislation_url%}
+					<dd>Read <a href="{{ boundary_review.legislation_url }}">the legislation</a> for this review</dd>
+				{% else %}
+					<dd>Legislation Link Missing</dd>
+				{% endif %}
+			</div>
+		</dl>
+	</div class="ds-card-body">
+</div>
+
+{% endblock content %}

--- a/every_election/apps/organisations/templates/organisations/organisationboundaryreview_detail.html
+++ b/every_election/apps/organisations/templates/organisations/organisationboundaryreview_detail.html
@@ -5,7 +5,7 @@
 <div class="ds-card">
 	<div class="ds-card-body">
 		<h1>
-			{{boundary_review_name}}
+			{{boundary_review.generic_title}}
 		</h1>
 
 		<dl class="ds-descriptions">

--- a/every_election/apps/organisations/templates/organisations/organisationboundaryreviews_list.html
+++ b/every_election/apps/organisations/templates/organisations/organisationboundaryreviews_list.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block page_title %}Boundary Reviews{% endblock page_title %}
+
+{% block content %}
+	{% for review in object_list%}
+		<h3>
+			<a href="{% url 'single_boundary_review_view' review.id %}">{{review.lgbce_review_title}}</a>
+		</h3>
+		<li><strong>Organisation</strong>: <a href={{review.divisionset.organisation.get_absolute_url}}>{{review.divisionset.organisation.name}}</a></li>
+		<li><strong>Consultation</strong>: <a href={{review.consultation_url}}>Link</a></li>
+		<li><strong>Legislation</strong>: <a href={{review.legislation_url}}>Link</a></li>
+
+	{% endfor %}
+
+{% endblock content %}

--- a/every_election/apps/organisations/templates/organisations/organisationboundaryreviews_list.html
+++ b/every_election/apps/organisations/templates/organisations/organisationboundaryreviews_list.html
@@ -2,13 +2,45 @@
 {% block page_title %}Boundary Reviews{% endblock page_title %}
 
 {% block content %}
-	{% for review in object_list%}
-		<h3>
-			<a href="{% url 'single_boundary_review_view' review.id %}">{{review.generic_title}}</a>
-		</h3>
-		<li><strong>Organisation</strong>: <a href={{review.divisionset.organisation.get_absolute_url}}>{{review.divisionset.organisation.name}}</a></li>
-		<li><strong>Consultation</strong>: <a href={{review.consultation_url}}>Link</a></li>
-		<li><strong>Legislation</strong>: <a href={{review.legislation_url}}>Link</a></li>
+
+<style>
+	.boundary_reviews_table {
+		font-size: 1rem;
+	}
+	.boundary_reviews_table td:first-child {
+		width: 50%;
+	}
+</style>
+
+{%regroup boundary_reviews by organisation as boundary_reviews_by_organisation%}
+{% for group in boundary_reviews_by_organisation %}
+	<h5>{{group.grouper}}</h5>
+	<div class="ds-table ds-bordered">
+		<table class="boundary_reviews_table">
+			<tr>
+				<th>Review</th>
+				<th>Consultation</th>
+				<th>Legislation</th>
+				<th>Status</th>
+			</tr>
+			{% for review in group.list%}
+				<tr>
+					<td><a href="{% url 'single_boundary_review_view' review.id %}">{{review.generic_title}}</a></td>
+					{%if review.consultation_url%}
+						<td>Read the <a href={{review.consultation_url}}>Consultation</a></td>
+					{%else%}	
+						<td>Consultation Link Missing</a></td>
+					{%endif%}
+					{%if review.legislation_url%}
+						<td>Read the <a href={{review.legislation_url}}>Legislation</a></td>
+					{%else%}	
+						<td>Legislation Link Missing</a></td>
+					{%endif%}
+					<td>{{review.get_status_display}}</td>
+				</tr>
+			{% endfor %}
+		</table>
+	</div>
 	{% endfor %}
 
 {% endblock content %}

--- a/every_election/apps/organisations/templates/organisations/organisationboundaryreviews_list.html
+++ b/every_election/apps/organisations/templates/organisations/organisationboundaryreviews_list.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block page_title %}Boundary Reviews{% endblock page_title %}
 
+
 {% block content %}
 
 <style>
@@ -12,7 +13,21 @@
 	}
 </style>
 
-{%regroup boundary_reviews by organisation as boundary_reviews_by_organisation%}
+<aside class="ds-filter" aria-labelledby="filter-label">
+	<h6>FILTERS:</h6>
+	<form>
+		<div class="ds-filter-cluster">
+			{% for field in filter.form %}
+				<ul aria-labelledby="adv-filter-label-{{ forloop.counter }}">
+					<li id="adv-filter-label-{{ forloop.counter }}" class="ds-filter-label" aria-hidden="true">{{ field.label }}:</li>
+					{{ field }}
+				</ul>
+			{% endfor %}
+		</div>
+	</form>
+</aside>
+
+{%regroup queryset by organisation as boundary_reviews_by_organisation%}
 {% for group in boundary_reviews_by_organisation %}
 	<h5>{{group.grouper}}</h5>
 	<div class="ds-table ds-bordered">

--- a/every_election/apps/organisations/templates/organisations/organisationboundaryreviews_list.html
+++ b/every_election/apps/organisations/templates/organisations/organisationboundaryreviews_list.html
@@ -3,7 +3,6 @@
 
 
 {% block content %}
-
 <style>
 	.boundary_reviews_table {
 		font-size: 1rem;
@@ -12,6 +11,8 @@
 		width: 50%;
 	}
 </style>
+
+<h2> Boundary Reviews </h2>
 
 <aside class="ds-filter" aria-labelledby="filter-label">
 	<h6>FILTERS:</h6>

--- a/every_election/apps/organisations/templates/organisations/organisationboundaryreviews_list.html
+++ b/every_election/apps/organisations/templates/organisations/organisationboundaryreviews_list.html
@@ -4,7 +4,7 @@
 {% block content %}
 	{% for review in object_list%}
 		<h3>
-			<a href="{% url 'single_boundary_review_view' review.id %}">{{review.lgbce_review_title}}</a>
+			<a href="{% url 'single_boundary_review_view' review.id %}">{{review.generic_title}}</a>
 		</h3>
 		<li><strong>Organisation</strong>: <a href={{review.divisionset.organisation.get_absolute_url}}>{{review.divisionset.organisation.name}}</a></li>
 		<li><strong>Consultation</strong>: <a href={{review.consultation_url}}>Link</a></li>

--- a/every_election/apps/organisations/templates/organisations/organisationboundaryreviews_list.html
+++ b/every_election/apps/organisations/templates/organisations/organisationboundaryreviews_list.html
@@ -9,7 +9,6 @@
 		<li><strong>Organisation</strong>: <a href={{review.divisionset.organisation.get_absolute_url}}>{{review.divisionset.organisation.name}}</a></li>
 		<li><strong>Consultation</strong>: <a href={{review.consultation_url}}>Link</a></li>
 		<li><strong>Legislation</strong>: <a href={{review.legislation_url}}>Link</a></li>
-
 	{% endfor %}
 
 {% endblock content %}

--- a/every_election/apps/organisations/templates/organisations/supported_organisations.html
+++ b/every_election/apps/organisations/templates/organisations/supported_organisations.html
@@ -8,7 +8,8 @@
             <div class="ds-card-body">
                 <h2>Supported Organisations</h2>
                 <p>The following is a list of organisations that this project supports.</p>
-                <p>That means, we track elections for organisations on this list</p>
+                <p>That means, we track elections for organisations on this list.</p>
+                <p>We also track <a href={% url "boundary_reviews_view" %}>boundary reviews</a> for these organisations.</p>
 
                 {% regroup object_list by organisation_type as grouped_list %}
 

--- a/every_election/apps/organisations/tests/test_organisation_models.py
+++ b/every_election/apps/organisations/tests/test_organisation_models.py
@@ -335,3 +335,17 @@ class TestOrganisationDivisionBoundaryReview(TestCase):
                 clean_url,
                 obr.cleaned_legislation_url,
             )
+
+    def test_generic_title(self):
+        self.assertEqual(
+            f"Boundary review for {self.incomplete_review.organisation.common_name} ({self.incomplete_review.status})",
+            self.incomplete_review.generic_title,
+        )
+        self.assertEqual(
+            self.unprocessed_review.legislation_title,
+            self.unprocessed_review.generic_title,
+        )
+        self.assertEqual(
+            self.processed_review.legislation_title,
+            self.processed_review.generic_title,
+        )

--- a/every_election/apps/organisations/urls.py
+++ b/every_election/apps/organisations/urls.py
@@ -4,11 +4,18 @@ from .views import (
     OrganisationDetailView,
     OrganisationsFilterView,
     SupportedOrganisationsView,
+    AllBoundaryReviewsView,
 )
 
 urlpatterns = [
     re_path(
         r"^$", SupportedOrganisationsView.as_view(), name="organisations_view"
+    ),
+    # a list of all boundary reviews
+    re_path(
+        r"^boundary_reviews/$",
+        AllBoundaryReviewsView.as_view(),
+        name="boundary_reviews_view",
     ),
     # canonical URL for a single organisation record
     re_path(

--- a/every_election/apps/organisations/urls.py
+++ b/every_election/apps/organisations/urls.py
@@ -1,10 +1,11 @@
 from django.urls import re_path
 
 from .views import (
+    AllBoundaryReviewsView,
     OrganisationDetailView,
     OrganisationsFilterView,
+    SingleBoundaryReviewView,
     SupportedOrganisationsView,
-    AllBoundaryReviewsView,
 )
 
 urlpatterns = [
@@ -16,6 +17,12 @@ urlpatterns = [
         r"^boundary_reviews/$",
         AllBoundaryReviewsView.as_view(),
         name="boundary_reviews_view",
+    ),
+    # a single boundary review record
+    re_path(
+        r"^boundary_reviews/(?P<boundary_review_id>.+)/$",
+        SingleBoundaryReviewView.as_view(),
+        name="single_boundary_review_view",
     ),
     # canonical URL for a single organisation record
     re_path(

--- a/every_election/apps/organisations/views/public.py
+++ b/every_election/apps/organisations/views/public.py
@@ -3,9 +3,9 @@ from datetime import datetime
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db.models import Prefetch, Q
 from django.http import Http404
-from django.views.generic import ListView, TemplateView
+from django.views.generic import DetailView, ListView, TemplateView
 from elections.models import Election
-from organisations.models import Organisation
+from organisations.models import Organisation, OrganisationBoundaryReview
 
 
 class SupportedOrganisationsView(ListView):
@@ -71,3 +71,23 @@ class OrganisationDetailView(TemplateView):
                 "api:organisation-geo", "json"
             )
         return context
+
+
+class AllBoundaryReviewsView(ListView):
+    template_name = "organisations/organisationboundaryreviews_list.html"
+    model = OrganisationBoundaryReview
+    context_object_name = "boundary_reviews"
+
+    def get_queryset(self):
+        return (
+            OrganisationBoundaryReview.objects.all()
+            .prefetch_related("organisation")
+            .prefetch_related("divisionset")
+        )
+
+
+class SingleBoundaryReviewView(DetailView):
+    model = OrganisationBoundaryReview
+    context_object_name = "boundary_review"
+    slug_field = "id"
+    slug_url_kwarg = "boundary_review_id"

--- a/every_election/apps/organisations/views/public.py
+++ b/every_election/apps/organisations/views/public.py
@@ -78,13 +78,21 @@ class AllBoundaryReviewsView(ListView):
     model = OrganisationBoundaryReview
     context_object_name = "boundary_reviews"
 
-    def get_queryset(self):
-        return (
+    def get_context_data(self, **kwargs):
+        from ..filters import OrganisationBoundaryReviewFilter
+
+        context = super().get_context_data(**kwargs)
+        qs = (
             OrganisationBoundaryReview.objects.all()
             .prefetch_related("organisation")
             .prefetch_related("divisionset")
             .order_by("organisation")
         )
+        f = OrganisationBoundaryReviewFilter(self.request.GET, qs)
+
+        context["filter"] = f
+        context["queryset"] = f.qs
+        return context
 
 
 class SingleBoundaryReviewView(DetailView):

--- a/every_election/apps/organisations/views/public.py
+++ b/every_election/apps/organisations/views/public.py
@@ -83,6 +83,7 @@ class AllBoundaryReviewsView(ListView):
             OrganisationBoundaryReview.objects.all()
             .prefetch_related("organisation")
             .prefetch_related("divisionset")
+            .order_by("organisation")
         )
 
 


### PR DESCRIPTION
Frontend for Boundary Reviews:

Completed:
- List view
     - Groups BRs by organisation
     - Has a filter component with filters for:
         - org
         - status
- Detail view
- Adds generic title property to BR model that determines what title to display for a review (w/ test)
- Adds a link to the list view from supported orgs page

Not yet implemented: 
- Adding maps to detail view

Notes:

- I wasn't sure if the filter logic should stay in filters.py or be added to the BR queryset model, but can easily move it over if that is better practice. Likewise, I wasn't sure if I should make tests for each filter option?
- I can add more properties to filter by or to display in the views if appropriate too

Testing:

Navigate to [supported orgs](http://localhost:8000/organisations/) and click on boundary reviews
Run `pytest`