### PR TITLE
Order API results by election group

### DIFF
--- a/every_election/apps/api/views.py
+++ b/every_election/apps/api/views.py
@@ -120,7 +120,7 @@ class ElectionViewSet(viewsets.ReadOnlyModelViewSet):
                 queryset = queryset.filter(group_type=None)
             else:
                 queryset = queryset.filter(group_type=identifier_type)
-        return queryset.order_by()
+        return queryset.order_by_group_type()
 
     def retrieve(self, request, *args, **kwargs):
         if not validate(kwargs["election_id"]):

--- a/every_election/apps/elections/managers.py
+++ b/every_election/apps/elections/managers.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.contrib.gis.db.models.functions import PointOnSurface
 from django.contrib.gis.geos import GEOSGeometry, Point
 from django.db import models
+from django.db.models import Case, When
 from django.utils import timezone
 from elections.query_helpers import get_point_from_postcode
 from organisations.models import (
@@ -88,6 +89,15 @@ class ElectionQuerySet(models.QuerySet):
         if update_modified:
             kwargs["modified"] = kwargs.get("modified", timezone.now())
         return super().update(**kwargs)
+
+    def order_by_group_type(self):
+        order = Case(
+            When(group_type="election", then=0),
+            When(group_type="organisation", then=1),
+            When(group_type="subtype", then=2),
+            When(group_type=None, then=3),
+        )
+        return self.order_by(order)
 
 
 class PublicElectionsManager(models.Manager.from_queryset(ElectionQuerySet)):


### PR DESCRIPTION
There was a bug when paging through a lot of election results where the order of the pages changed between requets. This meant that we coulnd't build a full election tree when consuming results (e.g some pages ended up duplicated, some ended up missing).

This change means that pages should be ordered in the same way when paging.

Fixes https://democracy-club-gp.sentry.io/issues/4654723460/?project=162062&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0

```[tasklist]
### PR Checklist
- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Have I rebased with the latest version of master?
- [x] Added PR labels
```
