### PR TITLE
Manage no seats total divisions

### DIFF
--- a/every_election/apps/elections/forms.py
+++ b/every_election/apps/elections/forms.py
@@ -114,12 +114,23 @@ class ElectionOrganisationDivisionForm(forms.Form):
         super().__init__(*args, **kwargs)
         if not self.division:
             return
+
         self.fields["seats_contested"] = forms.IntegerField(
-            max_value=self.division.seats_total,
+            max_value=self.division.seats_total or 0,
             min_value=0,
-            help_text=f"Up to {self.division.seats_total} seats total",
+            help_text=f"Up to {self.division.seats_total or 0} seats total",
             required=False,
         )
+
+        if not self.division.seats_total:
+            self.fields[
+                "seats_contested"
+            ].help_text = """
+            No seats contested set. Can't make elections for this division. Please ask an admin to set the seats total.
+            """
+            del self.fields["ballot_type"]
+            return
+
         self.fields["division_id"] = forms.CharField(
             initial=self.division.pk, required=False, widget=forms.HiddenInput
         )

--- a/every_election/apps/organisations/views/admin/organisation_division.py
+++ b/every_election/apps/organisations/views/admin/organisation_division.py
@@ -38,10 +38,16 @@ class OrganisationDivisionAdminForm(forms.ModelForm):
 
 
 class OrganisationDivisionAdmin(admin.ModelAdmin):
-    list_display = ("official_identifier", "name", "divisionset")
+    empty_value_display = "[NOT SET]"
+    list_display = ("official_identifier", "name", "seats_total", "divisionset")
     ordering = ("divisionset", "name")
     search_fields = ("official_identifier", "name")
-    list_filter = [CurrentDivisionFilter, TempIdFilter, "division_type"]
+    list_filter = [
+        CurrentDivisionFilter,
+        TempIdFilter,
+        "division_type",
+        "seats_total",
+    ]
     form = OrganisationDivisionAdminForm
     readonly_fields = ["created", "modified"]
 


### PR DESCRIPTION
This PR does two things:

1. Allows filtering on `seats_total` in the admin interface to let us see problems. 
2. Prevents making elections for divisions without a `seats_total`


![image](https://github.com/DemocracyClub/EveryElection/assets/242329/b64cc708-adfc-4629-802f-31627b981189)

This is in response to a problem where making some elections without `seats_total` raises a 500. Because we assume `seats_total` exists downstream, better to prevent the elections being made in the first place.

This affects all `parl` divisions at the moment. As well as this PR, I will manually set the `seats_total` to 1 for all UK parl divisions. 