### PR TITLE
Don't invalidate cache for each class instance

### DIFF
--- a/every_election/apps/elections/tests/test_create_ids.py
+++ b/every_election/apps/elections/tests/test_create_ids.py
@@ -15,10 +15,15 @@ from organisations.tests.factories import (
     OrganisationGeographyFactory,
 )
 
+from ..utils import reset_cache
 from .base_tests import BaseElectionCreatorMixIn, FuzzyInt
 
 
 class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
+    def setUp(self):
+        super().setUp()
+        reset_cache()
+
     def run_test_with_data(
         self, all_data, expected_ids, expected_titles, **kwargs
     ):
@@ -479,7 +484,7 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             "Greater London Assembly elections",
             "Greater London Assembly elections (Additional)",
         ]
-        with self.assertNumQueries(FuzzyInt(24, 25)):
+        with self.assertNumQueries(FuzzyInt(23, 25)):
             self.run_test_with_data(
                 all_data,
                 expected_ids,

--- a/every_election/apps/elections/tests/test_election_builder.py
+++ b/every_election/apps/elections/tests/test_election_builder.py
@@ -9,7 +9,7 @@ from elections.models import (
     ElectionSubType,
     ElectionType,
 )
-from elections.utils import ElectionBuilder
+from elections.utils import ElectionBuilder, reset_cache
 from organisations.models import Organisation, OrganisationDivision
 from organisations.tests.factories import (
     OrganisationDivisionFactory,
@@ -20,6 +20,10 @@ from .base_tests import BaseElectionCreatorMixIn
 
 
 class TestElectionBuilder(BaseElectionCreatorMixIn, TestCase):
+    def setUp(self):
+        super().setUp()
+        reset_cache()
+
     def test_eq(self):
         eb1 = ElectionBuilder("local", "2017-06-08")
 
@@ -67,6 +71,7 @@ class TestElectionBuilder(BaseElectionCreatorMixIn, TestCase):
         self.elected_role1.delete()
 
         with self.assertRaises(Organisation.ValidationError):
+            reset_cache()
             builder.with_organisation(self.org1)
 
     def test_organisation_date_range_invalid(self):
@@ -280,7 +285,7 @@ class TestElectionBuilder(BaseElectionCreatorMixIn, TestCase):
         Regression test for https://github.com/DemocracyClub/EveryElection/issues/1162
 
         If an ID exists for the organisation after creating a ballot ID, later
-        attempts to createt another balot ID for the org on the same day failed
+        attempts to create another ballot ID for the org on the same day failed
         due to a duplicate key error.
 
         """
@@ -294,9 +299,9 @@ class TestElectionBuilder(BaseElectionCreatorMixIn, TestCase):
         org_group = builder.build_organisation_group(election_group).save()
         ballot = builder.build_ballot(org_group)
         ballot.save()
-
+        reset_cache()
         # Later, a user submits another election for that organisation, on the
-        # same day, in a differnet division
+        # same day, in a different division
         builder = (
             ElectionBuilder("local", "2017-06-08")
             .with_organisation(self.org1)

--- a/every_election/apps/elections/utils.py
+++ b/every_election/apps/elections/utils.py
@@ -29,6 +29,14 @@ CACHE = {
 }
 
 
+def reset_cache():
+    global CACHE
+    NEW_CACHE = {}
+    for key in CACHE:
+        NEW_CACHE[key] = {}
+    CACHE = NEW_CACHE
+
+
 def get_voter_id_requirement(election: Election) -> Optional[str]:
     """
     Given an Election object, if eligible for voter ID return the related voter ID legislation code
@@ -93,10 +101,6 @@ def get_cached_elected_role(organisation, election_type):
 
 
 class ElectionBuilder:
-    def __del__(self):
-        for key in CACHE:
-            CACHE[key] = {}
-
     def __init__(self, election_type, date):
         # init params
         if type(election_type) == str:

--- a/every_election/apps/elections/views/id_creator.py
+++ b/every_election/apps/elections/views/id_creator.py
@@ -25,6 +25,7 @@ from elections.utils import (
     create_ids_for_each_ballot_paper,
     get_notice_directory,
     get_voter_id_requirement,
+    reset_cache,
 )
 from formtools.wizard.views import NamedUrlSessionWizardView
 from organisations.models import Organisation
@@ -372,7 +373,8 @@ class IDCreatorWizard(NamedUrlSessionWizardView):
             )
             se.status = "id_created"
             se.save()
-
+        # Reset the cache created for this ID creation
+        reset_cache()
         return HttpResponseRedirect("/")
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
This improves performance when creating a lot of elections

Before

![image](https://github.com/DemocracyClub/EveryElection/assets/242329/1da621f2-9f66-4f61-aae0-6d8393c161bb)


After 
![Screenshot from 2024-01-25 15-01-13](https://github.com/DemocracyClub/EveryElection/assets/242329/631f3086-2311-426b-9fcd-d00bf17d2b71)

:sunglasses: 
