### PR TITLE
Hotfix/cut down org elections endpoint queries

### DIFF
--- a/every_election/apps/api/serializers.py
+++ b/every_election/apps/api/serializers.py
@@ -197,10 +197,10 @@ class BaseElectionSerializer(serializers.ModelSerializer):
     def get_deleted(self, obj: Election):
         return obj.current_status == ModerationStatuses.deleted.value
 
-    def get_current(self, obj):
+    def get_current(self, obj: Election):
         return obj.get_current
 
-    def get_voting_system(self, obj):
+    def get_voting_system(self, obj: Election):
         if (
             obj.group_type == "organisation"
             or obj.group_type == "subtype"
@@ -212,7 +212,11 @@ class BaseElectionSerializer(serializers.ModelSerializer):
             return system
         return None
 
-    def get_children(self, obj):
+    def get_children(self, obj: Election) -> list[str]:
+        if not obj.group_type:
+            return []
+        if children := getattr(obj, "children", None):
+            return [c.election_id for c in children]
         if self.context["request"].query_params.get("deleted", None):
             children = (
                 obj.get_children("private_objects")

--- a/every_election/settings/base.py
+++ b/every_election/settings/base.py
@@ -286,8 +286,16 @@ CURRENT_FUTURE_DAYS = 90
 
 # .local.py overrides all the common settings.
 
+DEBUG_TOOLBAR = False
 with contextlib.suppress(ImportError):
     from .local import *  # noqa
+
+if not os.environ.get("DC_ENVIRONMENT") and DEBUG_TOOLBAR:
+    INSTALLED_APPS += ("debug_toolbar",)
+    MIDDLEWARE = [
+        "debug_toolbar.middleware.DebugToolbarMiddleware",
+    ] + MIDDLEWARE
+
 
 # importing test settings file if necessary
 if IN_TESTING:

--- a/every_election/settings/local.example.py
+++ b/every_election/settings/local.example.py
@@ -27,3 +27,6 @@ AWS_STORAGE_BUCKET_NAME = "notice-of-election-dev"
 # using cache sessions instead of database sessions
 # in dev makes it easier to debug the wizard
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
+
+# Turn Debug tool bar on or off
+DEBUG_TOOLBAR = True

--- a/every_election/urls.py
+++ b/every_election/urls.py
@@ -2,7 +2,7 @@ from core.views import HomeView
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.urls import include, re_path
+from django.urls import include, path, re_path
 from django.views.generic import TemplateView
 
 handler500 = "dc_utils.urls.dc_server_error"
@@ -23,6 +23,10 @@ urlpatterns = [
     ),
 ]
 
+if "debug_toolbar" in settings.INSTALLED_APPS:
+    urlpatterns.append(
+        path("__debug__/", include("debug_toolbar.urls")),
+    )
 
 if settings.DEBUG:
     urlpatterns += static(

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,3 +1,3 @@
 -r testing.txt
 
-
+django-debug-toolbar


### PR DESCRIPTION
How I've tested this:
* Checkout master
  * `time curl http://127.0.0.1:8000/api/organisations/parl/parl-hoc/1832-06-07/elections/?format=json | jq .[] > parl-before.json` (real	0m7.770s)
* checkout branch
  * `time curl http://127.0.0.1:8000/api/organisations/parl/parl-hoc/1832-06-07/elections/?format=json | jq .[] > parl-after.json` (real	0m0.962s)
* `git diff --no-index parl-before.json parl-after.json` (This removes all the elections with `"deleted": true`)

This is a change to the API, but it brings it into line with the `/api/elections/` endpoint

Before there were thousands of requests. Now there are 4. Using curl locally time has gone from around 7 seconds to under 1 second. This will be higher on prod, but hopefully enough of an improvement to stop it crashing. 

Curling dev deploy takes just under 8 seconds

fixes https://democracy-club-gp.sentry.io/issues/5054562655/?project=1281142&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=4


 