### PR TITLE
Hotfix/dc utils footer

### DIFF
--- a/every_election/templates/base.html
+++ b/every_election/templates/base.html
@@ -61,44 +61,29 @@
         {% endblock content %}
     </main>
 {% endblock main_base %}
-
-{% block footer_base %}
-    <footer class="ds-footer">
-        <div class="ds-block-centered ds-text-centered ds-stack">
-            <div class="ds-cluster-center">
-                <ul>
-                    <li><a href="{% url 'home' %}">Home</a></li>
-                    <li><a href="https://democracyclub.org.uk/about/">About</a></li>
-                    <li><a href="https://democracyclub.org.uk/privacy/">Privacy</a></li>
-                    <li><a href="https://democracyclub.org.uk/blog/">Blog</a></li>
-                    <li><a href="https://democracyclub.org.uk/contact/">Contact</a></li>
-                    <li><a href="https://democracyclub.org.uk/donate/">Donate</a></li>
-                    <li><a href="https://www.facebook.com/democracyclub/">Facebook</a></li>
-                    <li><a href="https://twitter.com/democlub">Twitter</a></li>
-                    <li><a href="https://github.com/DemocracyClub/EveryElection">GitHub</a></li>
-                </ul>
-                <div>
-                    <p>Democracy Club is a UK based Community Interest Company that builds
-                        the digital infrastructure needed for a 21st century democracy</p>
-                </div>
-                <div class="ds-copyright ds-width-full">
-                    <a class="ds-logo" href="https://democracyclub.org.uk/">
-                        <img src="{%  static "images/logo_icon.svg" %}" alt=""/>
-                        <span class="ds-text-left">democracy<br>club</span>
-                    </a>
-                    <p>Copyright &copy; {% now 'Y' %} Democracy Club</p>
-                    <p>Community Interest Company</p>
-                    <p>Company No: <a href="https://beta.companieshouse.gov.uk/company/09461226">09461226</a></p>
-
-                    <p>Contains OS data © Crown copyright and database right {% now 'Y' %}</p>
-                    <p>Contains Royal Mail data © Royal Mail copyright and database right {% now 'Y' %}</p>
-                    <p>Contains National Statistics data © Crown copyright and database right {% now 'Y' %}</p>
-                </div>
-            </div>
-        </div>
-    </footer>
-{% endblock footer_base %}
-
+{% block mailing_list %}{% endblock mailing_list %} 
+{% block footer_menu %} 
+<div class="ds-cluster-center">
+    <ul>
+        <li><a href="{% url 'home' %}">Home</a></li>
+        <li><a href="https://democracyclub.org.uk/about/">About</a></li>
+        <li><a href="https://democracyclub.org.uk/privacy/">Privacy</a></li>
+        <li><a href="https://democracyclub.org.uk/blog/">Blog</a></li>
+        <li><a href="https://democracyclub.org.uk/contact/">Contact</a></li>
+        <li><a href="https://democracyclub.org.uk/donate/">Donate</a></li>
+        <li><a href="https://www.facebook.com/democracyclub/">Facebook</a></li>
+        <li><a href="https://twitter.com/democlub">Twitter</a></li>
+        <li><a href="https://github.com/DemocracyClub/EveryElection">GitHub</a></li>
+    </ul>
+</div>
+{% endblock footer_menu %}  
+{% block extra_footer_text %}
+<div class="ds-copyright">
+    <p>Contains OS data © Crown copyright and database right {% now 'Y' %}</p>
+    <p>Contains Royal Mail data © Royal Mail copyright and database right {% now 'Y' %}</p>
+    <p>Contains National Statistics data © Crown copyright and database right {% now 'Y' %}</p>
+</div>
+{% endblock extra_footer_text %}        
 {% block extra_site_js %}
     {% javascript "scripts" %}
 {% endblock extra_site_js %}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,8 +34,8 @@ django-pipeline==2.1.0
 
 importlib-metadata==6.8.0
 
-git+https://github.com/DemocracyClub/design-system.git@0.4.4
-git+https://github.com/DemocracyClub/dc_django_utils.git@2.4.0
+git+https://github.com/DemocracyClub/design-system.git@0.4.6
+git+https://github.com/DemocracyClub/dc_django_utils.git@2.6.0
 
 django-dotenv==1.4.2
 


### PR DESCRIPTION
This change implements the footer changes with tags from dc_utils and fixes the right margin on the logo with a new version of design-system.

Although ultimately no changes were needed, this issue caused some confusion so flagging it here for others pyca/pyopenssl#1143 

Dependent on https://github.com/DemocracyClub/dc_django_utils/pull/65 and https://github.com/DemocracyClub/design-system/pull/115

<img width="309" alt="Screenshot 2024-03-22 at 1 20 31 PM" src="https://github.com/DemocracyClub/EveryElection/assets/7017118/e1c77169-ba42-494b-84f4-be7547a4bc51">
<img width="1010" alt="Screenshot 2024-03-22 at 2 19 40 PM" src="https://github.com/DemocracyClub/EveryElection/assets/7017118/25c0bda0-44b4-4f45-ab27-ab45db526635">


