### PR TITLE
remove per-instance crontab entries

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -82,9 +82,6 @@ hooks:
     - location: deployscripts/write_envfile.sh
       timeout: 300
       runas: root
-    - location: serverscripts/rebuild_local_db.sh
-      timeout: 900
-      runas: every_election
     - location: deployscripts/install_crontab.sh
       timeout: 900
       runas: root

--- a/cdk_stacks/stacks/command_runner.py
+++ b/cdk_stacks/stacks/command_runner.py
@@ -57,11 +57,11 @@ class EEOncePerTagCommandRunner(Stack):
             )
 
             # New elections
-            # self.add_job(
-            #     "snoop",
-            #     "cron(30 * * * ? *)",
-            #     "output-on-error ee-manage-py-command snoop",
-            # )
+            self.add_job(
+                "snoop",
+                "cron(30 * * * ? *)",
+                "output-on-error ee-manage-py-command snoop",
+            )
 
             # Generate map layers and sync to S3
             self.add_job(

--- a/cdk_stacks/stacks/command_runner.py
+++ b/cdk_stacks/stacks/command_runner.py
@@ -74,7 +74,7 @@ class EEOncePerTagCommandRunner(Stack):
             self.add_job(
                 "add_nuts1_tags",
                 "cron(15 2 * * ? *)",
-                """output-on-error ee-manage-py-command add_tags -u "https://s3.eu-west-2.amazonaws.com/ee.public.data/ons-cache/NUTS_Level_1_(January_2018)_Boundaries.gpkg" --fields '{"NUTS118NM": "value", "NUTS118CD": "key"}' --tag-name NUTS1 --is-gpkg""",
+                "output-on-error /var/www/every_election/repo/serverscripts/add_nuts1.sh",
             )
 
             # Scrape LGBCE

--- a/deployscripts/crontab
+++ b/deployscripts/crontab
@@ -1,7 +1,4 @@
 # WARNING: Commands in this file will run on *every* instance in *every* environment
-# HOWEVER: these commands will NOT run on instances booted from the EE AMI
+# HOWEVER: these commands will NOT run on instances
+# booted from the EE AMI (i.e: WDIV installs running a "local" EE)
 # If you want to have a command run only once per env / once globally, use SSM Run Command
-0 2 * * * every_election cd /var/www/every_election/repo && ./serverscripts/rebuild_local_db.sh
-30 2 * * * every_election cd /var/www/every_election/repo && ./serverscripts/add_nuts1.sh
-0 1 * * * every_election ee-manage-py-command dumpdata elections election_snooper --indent 4 -o /var/www/every_election/repo/every_election/data/elections.json
-0 0 * * * every_election ee-manage-py-command snoop

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@ beautifulsoup4==4.12.1
 boto3==1.34.148
 botocore==1.34.148
 commitment==3.0.1
-Django==4.2.11
+Django==4.2.15
 django-cors-headers==4.2.0
 django-extensions==3.2.3
 django-filter==24.2


### PR DESCRIPTION
Right. So I did some digging.
All of these commands actually are running on the EE prod server(s).
EE has been restoring itself from a copy of its own backup every night :scream_cat: 

I don't think it was the intent that these jobs should have been running on WDIV servers running their own EE instance. We definitely wouldn't have wanted them running `snoop` for example, and `sync_elections` is there as an _alternative_ to restoring from backup every night.

Also a bit worried that we have no log aggregation and not really any visibility on these cron jobs, but I'm not going to do anything about those problems here.

This is one of those PRs that asks a lot of questions as well as answering some, so I'm going to leave some comments inline.