### PR TITLE
updates to build ubuntu 24.04 EE base image

### DIFF
--- a/cdk_settings.json
+++ b/cdk_settings.json
@@ -1,4 +1,4 @@
 {
-  "base_ami_id": "ami-0a42229bb96342af5",
-  "recipe_version": "0.0.34"
+  "base_ami_id": "ami-0c40c7ef04b5ab961",
+  "recipe_version": "0.0.35"
 }

--- a/cdk_stacks/components/install_app.yml
+++ b/cdk_stacks/components/install_app.yml
@@ -1,7 +1,7 @@
 name: InstallApp
 description: Installs the EE Django app
 schemaVersion: 1.0
-component_version: 0.0.21
+component_version: 0.0.22
 parameters:
   - git_branch:
       type: string
@@ -18,7 +18,7 @@ phases:
         action: ExecuteBash
         inputs:
           commands:
-            - sudo apt-get install -y postgresql-client postgresql-common python3-dev libpq-dev gdal-bin libproj-dev jq postgresql-14-postgis-3 nodejs npm
+            - sudo apt-get install -y postgresql-client postgresql-common python3-dev libpq-dev gdal-bin libproj-dev jq postgresql-16-postgis-3 nodejs npm
       - name: make_directories
         action: ExecuteBash
         inputs:
@@ -110,7 +110,7 @@ phases:
               ExecReload=/bin/kill -s HUP $MAINPID
               ExecStop=/bin/kill -s TERM $MAINPID
               [Install]
-              WantedBy=multi-user.target            
+              WantedBy=multi-user.target
 
       - name: StartAndEnableGunicornService
         action: ExecuteBash


### PR DESCRIPTION
this is just the bits extracted from #2198 that will allow us to build a new EE_IMAGE without merging that whole PR