### PR TITLE
Fix LGBCE scraper

### DIFF
--- a/every_election/apps/organisations/boundaries/boundary_bot/scraper.py
+++ b/every_election/apps/organisations/boundaries/boundary_bot/scraper.py
@@ -70,6 +70,7 @@ class LgbceScraper:
             "greater-london",
             "north-yorkshire",
             "somerset",
+            "north-warwickshire",  # LGBCE site links to webarchive version of legislation rather than legislation.gov.uk
         ]
 
     def scrape_index(self):

--- a/every_election/apps/organisations/boundaries/boundary_bot/scraper.py
+++ b/every_election/apps/organisations/boundaries/boundary_bot/scraper.py
@@ -1,4 +1,5 @@
 import pprint
+import re
 
 import lxml.html
 import requests
@@ -181,6 +182,14 @@ class LgbceScraper:
         return OrganisationBoundaryReview.objects.filter(
             organisation=org, slug=record["slug"]
         ).exclude(status=ReviewStatus.COMPLETED)
+
+    def clean_legislation_url(self, url):
+        url = url.replace("/id/", "/")
+        url = re.search(
+            r"(?:www\.)?legislation.gov.uk/(wsi|ukdsi|uksi|ssi)/\d+/\d+",
+            url,
+        ).group()
+        return f"https://{url}"
 
     def validate(self):
         # perform some consistency checks

--- a/every_election/apps/organisations/boundaries/boundary_bot/scraper.py
+++ b/every_election/apps/organisations/boundaries/boundary_bot/scraper.py
@@ -163,17 +163,21 @@ class LgbceScraper:
         return org
 
     def get_review_from_db(self, record):
-        if record["legislation_title"]:
+        if record["legislation_url"]:
+            legislation_year = self.get_legislation_year(
+                record["legislation_url"]
+            )
+
             try:
                 result = OrganisationBoundaryReview.objects.filter(
-                    legislation_title=record["legislation_title"],
+                    legislation_url__contains=f"/{legislation_year}/",
                     slug=record["slug"],
                 )
                 if len(result) == 1:
                     return result
                 if len(result) > 1:
                     raise ScraperException(
-                        f"More than one review found with same legislation_title: {record['legislation_title']}"
+                        f"More than one review found for {record['slug']} with year {legislation_year}",
                     )
             except OrganisationBoundaryReview.DoesNotExist:
                 pass

--- a/every_election/apps/organisations/boundaries/boundary_bot/scraper.py
+++ b/every_election/apps/organisations/boundaries/boundary_bot/scraper.py
@@ -1,5 +1,6 @@
 import pprint
 import re
+from urllib.parse import urlparse
 
 import lxml.html
 import requests
@@ -190,6 +191,16 @@ class LgbceScraper:
             url,
         ).group()
         return f"https://{url}"
+
+    def get_legislation_year(self, url):
+        try:
+            cleaned_url = self.clean_legislation_url(url)
+        except AttributeError:
+            raise ScraperException(f"Failed to clean legislation URL: {url}")
+
+        urlparse_result = urlparse(cleaned_url)
+        path = urlparse_result.path
+        return path.split("/")[2]
 
     def validate(self):
         # perform some consistency checks

--- a/every_election/apps/organisations/boundaries/boundary_bot/tests/test_scraper.py
+++ b/every_election/apps/organisations/boundaries/boundary_bot/tests/test_scraper.py
@@ -227,3 +227,57 @@ class TestScraperSaves(TestCase):
                 slug="allerdale"
             ).legislation_title,
         )
+
+
+class TestGetLegislationYear(TestCase):
+    def setUp(self):
+        self.scraper = LgbceScraper(False, False)
+
+    def test_get_legislation_year_uksi_url(self):
+        legislation_url = "https://www.legislation.gov.uk/uksi/2023/1023/made"
+        year = self.scraper.get_legislation_year(legislation_url)
+        self.assertEqual(year, "2023")
+
+    def test_get_legislation_year_uksi_url_with_id(self):
+        legislation_url = "http://www.legislation.gov.uk/id/uksi/2023/732"
+        year = self.scraper.get_legislation_year(legislation_url)
+        self.assertEqual(year, "2023")
+
+    def test_get_legislation_year_no_subdomain(self):
+        legislation_url = "legislation.gov.uk/id/uksi/2023/732"
+        year = self.scraper.get_legislation_year(legislation_url)
+        self.assertEqual(year, "2023")
+
+    def test_get_legislation_year_ukdsi_url(self):
+        legislation_url = (
+            "https://www.legislation.gov.uk/ukdsi/2024/9780348262735/contents"
+        )
+        year = self.scraper.get_legislation_year(legislation_url)
+        self.assertEqual(year, "2024")
+
+    def test_get_legislation_year_wsi_url(self):
+        legislation_url = (
+            "https://www.legislation.gov.uk/wsi/2021/1081/contents/made"
+        )
+        year = self.scraper.get_legislation_year(legislation_url)
+        self.assertEqual(year, "2021")
+
+    def test_get_legislation_year_ssi_url(self):
+        legislation_url = "https://www.legislation.gov.uk/ssi/2021/370/made"
+        year = self.scraper.get_legislation_year(legislation_url)
+        self.assertEqual(year, "2021")
+
+    def test_get_legislation_year_invalid_url(self):
+        legislation_url = "https://www.invalid-url.com/uksi/2023/1023/made"
+        with self.assertRaises(ScraperException):
+            self.scraper.get_legislation_year(legislation_url)
+
+    def test_get_legislation_year_no_url(self):
+        legislation_url = ""
+        with self.assertRaises(ScraperException):
+            self.scraper.get_legislation_year(legislation_url)
+
+    def test_get_legislation_year_malformed_url(self):
+        legislation_url = "https://www.legislation.gov.uk/uksi/2023"
+        with self.assertRaises(ScraperException):
+            self.scraper.get_legislation_year(legislation_url)

--- a/every_election/apps/organisations/boundaries/boundary_bot/tests/test_validation.py
+++ b/every_election/apps/organisations/boundaries/boundary_bot/tests/test_validation.py
@@ -79,6 +79,9 @@ class ValidationTests(TestCase):
             "legislation_title"
         ] = "The Allerdale Electoral Change order"
         scraper.data["allerdale"]["latest_event"] = "Effective date"
+        scraper.data["allerdale"][
+            "legislation_url"
+        ] = "https://www.legislation.gov.uk/uksi/2017/1067/contents/made"
         scraper.data["allerdale"]["legislation_made"] = 1
         scraper.data["allerdale"]["status"] = ReviewStatus.COMPLETED
         scraper.save()

--- a/every_election/apps/organisations/boundaries/management/commands/remove_duplicate_reviews.py
+++ b/every_election/apps/organisations/boundaries/management/commands/remove_duplicate_reviews.py
@@ -1,0 +1,43 @@
+from django.core.management import BaseCommand
+from organisations.models import OrganisationBoundaryReview
+
+
+class Command(BaseCommand):
+    help = "One-off command to remove duplicated boundary reviews from database"
+
+    # We have a bunch of duplicated boundary reviews in the database that had been caused by minor changes
+    # to legislation titles on the LGCE site that our scraper was seeing as entirely new reviews.
+    # This command removes the duplicated reviews that aren't attached to a divisionset because they are redundant,
+    # and they causing the updated scraper to fail.
+    def handle(self, *args, **options):
+        ids = [
+            774,
+            836,
+            904,
+            926,
+            762,
+            767,
+            783,
+            798,
+            818,
+            821,
+            829,
+            846,
+            848,
+            862,
+            864,
+            876,
+            881,
+            887,
+            899,
+            905,
+            820,
+            828,
+            842,
+        ]
+        OrganisationBoundaryReview.objects.filter(id__in=ids).delete()
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Successfully removed {len(ids)} boundary reviews."
+            )
+        )

--- a/every_election/apps/organisations/boundaries/management/commands/update_reviews_with_bad_links.py
+++ b/every_election/apps/organisations/boundaries/management/commands/update_reviews_with_bad_links.py
@@ -1,0 +1,27 @@
+from django.core.management import BaseCommand
+from organisations.models import OrganisationBoundaryReview
+
+
+class Command(BaseCommand):
+    help = (
+        "One-off command to update boundary reviews with bad legislation links"
+    )
+
+    def handle(self, *args, **options):
+        # The Carlisle (Electoral Changes) Order 2019
+        self.update_review(
+            653, "https://www.legislation.gov.uk/uksi/2019/280/contents/made"
+        )
+        # The North Somerset (Electoral Changes) Order 2014
+        self.update_review(
+            664, "https://www.legislation.gov.uk/uksi/2014/3291/contents/made"
+        )
+
+    def update_review(self, review_id, correct_legislation_url):
+        review = OrganisationBoundaryReview.objects.get(id=review_id)
+        old_link = review.legislation_url
+        review.legislation_url = correct_legislation_url
+        review.save()
+        self.stdout.write(
+            f"Updated legislation link for {review.generic_title} from {old_link} to {review.legislation_url}"
+        )


### PR DESCRIPTION
co-authoured with @awdem 

This PR makes some changes to how the LGCE scraper works and should get it to run again. 

Before, the scraper first tried to `legislation_title` and `slug`  to determine if a review existed in our database. 

This PR changes it to use the `legislation_year`  in place of `legislation_title`. We extract `legislation_year` from the `legislation_url` of each scraped record, when there is a url.


TESTING:

For specific pytest changes/additions:
```
pytest every_election/apps/organisations/boundaries/boundary_bot/tests/test_scraper.py
pytest every_election/apps/organisations/boundaries/boundary_bot/tests/test_validation.py
```

To run the scraper, make sure you've restored your local database to a recent backup then run:
```
# The following commands fix some issues in the database that were causing the scraper to fail 
python manage.py remove_duplicate_reviews
python manage.py update_reviews_with_bad_links
# Run the scraper:
python manage.py scrape_lgbce
```
The scraper should run to completion without raising any errors and end with a list of slack messages and github PRs to create (it won't actually create them).
