### PR TITLE
adds missing seat total pattern to lgbce review helper

### DIFF
--- a/every_election/apps/organisations/boundaries/lgbce_review_helper.py
+++ b/every_election/apps/organisations/boundaries/lgbce_review_helper.py
@@ -228,6 +228,9 @@ class LGBCEReviewHelper:
         https://www.legislation.gov.uk/uksi/2022/1373/made
             '(4) The number of councillors to be elected for each ward is two. '
 
+        https://www.legislation.gov.uk/uksi/2024/124/made
+            'The number of councillors to be elected for each electoral division is one'
+
         https://www.legislation.gov.uk/uksi/2023/1205/article/3/made '(4) The number of councillors to be elected for
         each ward is the number specified in relation to that ward in the second column of the table in Schedule 1.'
 
@@ -236,10 +239,8 @@ class LGBCEReviewHelper:
         1. '
         """
         numbers_as_words = "(one|two|three|four|five|six|seven|eight|nine)"
-        words_after_numbers = (
-            f"{numbers_as_words} councillors are to be elected for each ward."
-        )
-        words_before_numbers = f"The number of councillors to be elected for each ward is {numbers_as_words}"
+        words_after_numbers = f"{numbers_as_words} councillors are to be elected for each (?:ward|electoral division)."
+        words_before_numbers = f"The number of councillors to be elected for each (?:ward|electoral division) is {numbers_as_words}"
         elected_councillors_pattern = re.compile(
             f"({words_after_numbers})|({words_before_numbers})",
             re.IGNORECASE | re.UNICODE,


### PR DESCRIPTION
This piece of [ECO legislation](https://www.legislation.gov.uk/uksi/2024/124/made) uses the words 'electoral division' instead of 'ward' when stating the number of councillors in the text (see (4)):

```
Electoral divisions of Northumberland and number of councillors
 3.—(1) The existing electoral divisions of Northumberland are abolished.

   (2) Northumberland is divided into the 69 electoral divisions listed in Schedule 1.

   (3) Each electoral division comprises the area identified on the map by reference to the name of the electoral division.

   (4) The number of councillors to be elected for each electoral division is one.
```
This difference in wording caused `get_seats_total_from_legislation` to raise an error when I hit the `write to S3` button because it only matches the equivalent text with the word 'ward'. 

I've refactored `get_seats_total_from_legislation` to handle either 'ward' or 'electoral division' in the text.


