### PR TITLE
Bugfix/fix lgbce scraper ignored orgs

### DIFF
--- a/every_election/apps/organisations/boundaries/boundary_bot/scraper.py
+++ b/every_election/apps/organisations/boundaries/boundary_bot/scraper.py
@@ -192,7 +192,7 @@ class LgbceScraper:
     def clean_legislation_url(self, url):
         url = url.replace("/id/", "/")
         url = re.search(
-            r"(?:www\.)?legislation.gov.uk/(wsi|ukdsi|uksi|ssi)/\d+/\d+",
+            r"(?:www\.)?legislation.gov.uk/(wsi|ukdsi|uksi|ssi|ukpga)/\d+/\d+",
             url,
         ).group()
         return f"https://{url}"

--- a/every_election/apps/organisations/boundaries/boundary_bot/scraper.py
+++ b/every_election/apps/organisations/boundaries/boundary_bot/scraper.py
@@ -66,11 +66,8 @@ class LgbceScraper:
         self.BOOTSTRAP_MODE = BOOTSTRAP_MODE
         self.SEND_NOTIFICATIONS = SEND_NOTIFICATIONS
         self.ignore = [
-            "east-hertfordshire",
-            "greater-london",
-            "north-yorkshire",
-            "somerset",
-            "north-warwickshire",  # LGBCE site links to webarchive version of legislation rather than legislation.gov.uk
+            "east-hertfordshire",  # LGBCE site has 'Name of Order' in the div used to parse legislation title and link so the scraper thinks its a new review (https://www.lgbce.org.uk/all-reviews/east-hertfordshire)
+            "north-warwickshire",  # LGBCE site links to webarchive version of legislation rather than legislation.gov.uk (https://www.lgbce.org.uk/all-reviews/north-warwickshire)
         ]
 
     def scrape_index(self):

--- a/every_election/apps/organisations/boundaries/boundary_bot/tests/test_scraper.py
+++ b/every_election/apps/organisations/boundaries/boundary_bot/tests/test_scraper.py
@@ -260,6 +260,13 @@ class TestGetLegislationYear(TestCase):
         year = self.scraper.get_legislation_year(legislation_url)
         self.assertEqual(year, "2024")
 
+    def test_get_legislation_year_ukpga_url(self):
+        legislation_url = (
+            "https://www.legislation.gov.uk/ukpga/1999/29/contents"
+        )
+        year = self.scraper.get_legislation_year(legislation_url)
+        self.assertEqual(year, "1999")
+
     def test_get_legislation_year_wsi_url(self):
         legislation_url = (
             "https://www.legislation.gov.uk/wsi/2021/1081/contents/made"


### PR DESCRIPTION
This PR refactors the parser for boundary bot to be able to parse structural change orders and the greater london authority. It also removes the relevant ignored orgs from the ignore list and updates the remaining ignored orgs with comments so when we look back at this in 100 years know why they're ignored. 

I've also had to update prod's database with minor changes to prep for this merge:

1) added an 'in progress' review for the GLA Act 1999 for the scraper to mark complete when it next scrapes
2) Updated the slugs for the existing pairs of north yorkshire and somerset structural change boundary review records so that they appear as unique to the scraper.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208330037668339