### PR TITLE
prune uv cache before persisting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,10 @@ jobs:
           command: |
             . .venv/bin/activate
             safety check
+
+      - run:
+          name: Prune UV cache
+          command: uv cache prune --ci
       - save_cache:
           paths:
             - ./.venv
@@ -111,6 +115,9 @@ jobs:
           . .venv/bin/activate
           uv sync --only-group cdk
 
+    - run:
+        name: Prune UV cache
+        command: uv cache prune --ci
     - save_cache:
         paths:
           - ./.venv


### PR DESCRIPTION
As recommended by https://docs.astral.sh/uv/concepts/cache/#caching-in-continuous-integration

Run `uv cache prune --ci` before we perisist `$HOME/.cache/uv` to cache