### PR TITLE
raise if we get error fetching lookup_name_to_registry

### DIFF
--- a/every_election/apps/organisations/boundaries/boundary_bot/code_matcher.py
+++ b/every_election/apps/organisations/boundaries/boundary_bot/code_matcher.py
@@ -17,6 +17,7 @@ class CodeMatcher:
         r = requests.get(
             "https://raw.githubusercontent.com/mysociety/uk_local_authority_names_and_codes/main/data/lookup_name_to_registry.csv"
         )
+        r.raise_for_status()
 
         csv_reader = csv.DictReader(r.text.splitlines())
         return list(csv_reader)

--- a/every_election/apps/organisations/boundaries/management/commands/scrape_lgbce.py
+++ b/every_election/apps/organisations/boundaries/management/commands/scrape_lgbce.py
@@ -3,7 +3,7 @@ from organisations.boundaries.boundary_bot.scraper import LgbceScraper
 
 
 class Command(BaseCommand):
-    help = "Copy all of the division and geography objects from one DivisionSet to another"
+    help = "Scrape LGBCE website for boundary reviews"
 
     def add_arguments(self, parser):
         parser.add_argument(


### PR DESCRIPTION
Refs https://democracy-club-gp.sentry.io/issues/6056737616

We hit this error running Boundary Bot last night.
I tried running locally to see if I could reproduce it, but no dice.
My guess is this will just work tomorrow.

My theory about what happened is: We got some kind of transient error fetching the file from github (which we ignored). The error response contained a non-200 OK status code and a response body which then did parse into a "valid" CSV file but didn't match our expected format.

I propose we add a `r.raise_for_status()` after we fetch the file. This would make that class of error more explicit if it happened again and it is good practice anyway. If we see this error again, we can review.

Also, while I was working on that: Quick drive by fix for the help text on the management command. Looks like a copy & paste error.