### PR TITLE
silence sentry DisallowedHost errors

### DIFF
--- a/every_election/settings/base.py
+++ b/every_election/settings/base.py
@@ -325,6 +325,9 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 if sentry_dsn := os.environ.get("SENTRY_DSN"):
     import sentry_sdk
     from sentry_sdk.integrations import django
+    from sentry_sdk.integrations.logging import ignore_logger
+
+    ignore_logger("django.security.DisallowedHost")
 
     sentry_sdk.init(
         dsn=sentry_dsn,


### PR DESCRIPTION
Refs https://app.asana.com/0/1205090401342417/1208407136740662/f

In order to test this locally, I set up my local dev copy with a sentry DSN and defined a custom environment. So https://democracy-club-gp.sentry.io/issues/?environment=CHRIS&project=1281142&referrer=issue-stream&statsPeriod=90d&stream_index=0 (note `environment=CHRIS` there) is me triggering some real `DisallowedHost` errors with my dev copy. Then I made sure that these changes were suppressing the same error.

Given our sentry config has got a bit more complicated I opted to also split it out into its own file.

I plan to apply similar changes to our other "noisy" apps.