### PR TITLE
fetch mysociety names and codes using GitHub Contents API

### DIFF
--- a/every_election/apps/organisations/boundaries/boundary_bot/code_matcher.py
+++ b/every_election/apps/organisations/boundaries/boundary_bot/code_matcher.py
@@ -1,4 +1,5 @@
 import csv
+from base64 import b64decode
 
 import requests
 from rapidfuzz import process
@@ -14,12 +15,14 @@ class CodeMatcher:
         }
 
     def get_data(self):
-        r = requests.get(
-            "https://raw.githubusercontent.com/mysociety/uk_local_authority_names_and_codes/main/data/lookup_name_to_registry.csv"
+        resp = requests.get(
+            "https://api.github.com/repos/mysociety/uk_local_authority_names_and_codes/contents/data/lookup_name_to_registry.csv"
         )
-        r.raise_for_status()
+        resp.raise_for_status()
+        body = resp.json()
+        decoded = b64decode(body["content"]).decode("utf-8")
 
-        csv_reader = csv.DictReader(r.text.splitlines())
+        csv_reader = csv.DictReader(decoded.splitlines())
         return list(csv_reader)
 
     def get_register_code(self, name):


### PR DESCRIPTION
For the last 4 days in a row, boundary bot has failed due to getting a 403 from GitHub trying to call https://raw.githubusercontent.com/mysociety/uk_local_authority_names_and_codes/main/data/lookup_name_to_registry.csv

I'm not really sure why, and this doesn't reproduce locally for me but I switching over to the GitHub contents API should work round this. In order to test this, I SSHd into a prod instance, and started a django shell.

Then I did

```
>>> import requests
>>> r = requests.get('https://raw.githubusercontent.com/mysociety/uk_local_authority_names_and_codes/main/data/lookup_name_to_registry.csv')
```

and confirmed that fails with a 403. Just for completeness, the full response body we get back is

```
<!DOCTYPE html>
<html>
  <head>
    <meta content="origin" name="referrer">
    <title>Forbidden &middot; GitHub</title>
    <style type="text/css" media="screen">
      body {
        background-color: #f1f1f1;
        margin: 0;
      }
      body,
      input,
      button {
        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
      }
      .container { margin: 30px auto 40px auto; width: 800px; text-align: center; }
      a { color: #4183c4; text-decoration: none; font-weight: bold; }
      a:hover { text-decoration: underline; }
      h1, h2, h3 { color: #666; }
      ul { list-style: none; padding: 25px 0; }
      li {
        display: inline;
        margin: 10px 50px 10px 0px;
      }
      .logo { display: inline-block; margin-top: 35px; }
      .logo-img-2x { display: none; }
      @media
      only screen and (-webkit-min-device-pixel-ratio: 2),
      only screen and (   min--moz-device-pixel-ratio: 2),
      only screen and (     -o-min-device-pixel-ratio: 2/1),
      only screen and (        min-device-pixel-ratio: 2),
      only screen and (                min-resolution: 192dpi),
      only screen and (                min-resolution: 2dppx) {
        .logo-img-1x { display: none; }
        .logo-img-2x { display: inline-block; }
      }
    </style>
  </head>
  <body>

    <div class="container">
      <h1>Access to this site has been restricted.</h1>

      <p>
        <br>
        If you believe this is an error,
        please contact <a href="https://support.github.com">Support</a>.
      </p>

      <div id="s">
        <a href="https://githubstatus.com">GitHub Status</a> &mdash;
        <a href="https://twitter.com/githubstatus">@githubstatus</a>
      </div>
    </div>
  </body>
</html>
```

Just out of interest, I also tried fetching some other files like https://raw.githubusercontent.com/DemocracyClub/EveryElection/refs/heads/master/manage.py and got the same issue. So I guess maybe that specific server has triggered an abuse mechanism or something.

Anyway. Then I ran

```
>>> r = requests.get('https://api.github.com/repos/mysociety/uk_local_authority_names_and_codes/contents/data/lookup_name_to_registry.csv')
```

and confirmed that is not blocked. So I have a reasonable level of confidence this will get us working again.

Note: CDK Synth failing on this repo too