### PR TITLE
Add management command to update `requires_voter_id` property

### DIFF
--- a/every_election/apps/elections/admin.py
+++ b/every_election/apps/elections/admin.py
@@ -153,7 +153,6 @@ class ElectionAdmin(admin.ModelAdmin):
         "friendly_group_type",
         "group",
         "seats_total",
-        "requires_voter_id",
         "snooped_election",
         "organisation",
         "division",

--- a/every_election/apps/elections/management/commands/refresh_voter_id.py
+++ b/every_election/apps/elections/management/commands/refresh_voter_id.py
@@ -1,0 +1,36 @@
+from django.core.management import BaseCommand
+from elections.models import Election
+from elections.utils import get_voter_id_requirement
+
+
+class Command(BaseCommand):
+    help = """
+    This command refreshes the requires_voter_id property on a given election
+    and any descendents. Use this command if we've just updated the
+    uk-election-ids library with new ID requirements which affect elections we
+    have already created in EE.
+
+    Example usage:
+    python manage.py refresh_voter_id local.city-of-london.2025-03-20
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "election",
+            type=str,
+            help="Election to update. Specifying an election group or organisation group will refresh all child ballots",
+        )
+
+    def handle(self, *args, **options):
+        election_id = options["election"]
+        elections = (
+            Election.public_objects.get(election_id=election_id)
+            .get_descendents("public_objects", inclusive=True)
+            .order_by("election_id")
+        )
+        self.stdout.write(f"updating {elections.count()} elections..")
+        for election in elections:
+            self.stdout.write(f"updating {election.election_id}..")
+            election.requires_voter_id = get_voter_id_requirement(election)
+            election.save()
+        self.stdout.write("..done!")


### PR DESCRIPTION
Refs: https://app.asana.com/0/1204880927741389/1208687275764621/f

As agreed, I'm making 2 changes in this PR:

1. Enable editing `requires_voter_id` in the django admin
2. Add management command to update `requires_voter_id` property

That said, cards on the table: This should have been a really simple PR, but I have got a bit distracted by some architecture astronauting here and made it a bit more complicated. I promise it is good architecture astronauting though!

In terms of solving the original problem, once this is deployed I'll

- SSH in
- run `python manage.py refresh_voter_id local.city-of-london.2025-03-20`

and then the next step will be to work out whether that just magically syncs through to everywhere else or not.