### PR TITLE
Hotfix/fixes to allow ukdsi links in eco processing

### DIFF
--- a/every_election/apps/organisations/boundaries/lgbce_review_helper.py
+++ b/every_election/apps/organisations/boundaries/lgbce_review_helper.py
@@ -196,7 +196,10 @@ class LGBCEReviewHelper:
 
         parts = ["schedule/1", "schedule", "schedules"]
         for part in parts:
-            xml_link = f"{eco_url}/{part}/made/data.xml"
+            xml_resource_path = (
+                "/made/data.xml" if "ukdsi" not in eco_url else "/data.xml"
+            )
+            xml_link = f"{eco_url}/{part}{xml_resource_path}"
             response = requests.head(xml_link, allow_redirects=True)
             if response.status_code == 200:
                 return xml_link

--- a/every_election/apps/organisations/boundaries/tests/test_lgbce_review_helper.py
+++ b/every_election/apps/organisations/boundaries/tests/test_lgbce_review_helper.py
@@ -337,6 +337,102 @@ class TestLGBCEReviewHelper(TestCase):
                 ),
             )
 
+    def test_get_xml_link_from_ukdsi_eco_url_a(self):
+        def get_responses(link, **kwargs):
+            """
+            The method being tested 'heads' the links generated to determine if they
+            return a 200. So we need to mock some respnses
+            """
+            mock = Mock()
+            tail = "/".join(link.split("/")[6:])
+            match tail:
+                case "schedule/1/data.xml":
+                    mock.status_code = 200
+                    return mock
+                case "schedule/data.xml":
+                    mock.status_code = 404
+                    return mock
+                case "schedules/made/data.xml":
+                    mock.status_code = 404
+                    return mock
+                case _:
+                    mock.status_code = 404
+                    return mock
+
+        with patch("requests.head", side_effect=get_responses) as mock_head:
+            mock_head.return_value = Mock(side_effect=get_responses)
+            lgbce_review_helper = LGBCEReviewHelper()
+            self.assertEqual(
+                "https://www.legislation.gov.uk/ukdsi/2024/9780348263176/schedule/1/data.xml",
+                lgbce_review_helper.get_xml_link_from_eco_url(
+                    "https://www.legislation.gov.uk/ukdsi/2024/9780348263176"
+                ),
+            )
+
+    def test_get_xml_link_from_ukdsi_eco_url_b(self):
+        def get_responses(link, **kwargs):
+            """
+            The method being tested 'heads' the links generated to determine if they
+            return a 200. So we need to mock some responses.
+            """
+            mock = Mock()
+            tail = "/".join(link.split("/")[6:])
+            match tail:
+                case "schedule/1/data.xml":
+                    mock.status_code = 404
+                    return mock
+                case "schedule/data.xml":
+                    mock.status_code = 200
+                    return mock
+                case "schedules/data.xml":
+                    mock.status_code = 404
+                    return mock
+                case _:
+                    mock.status_code = 404
+                    return mock
+
+        with patch("requests.head", side_effect=get_responses) as mock_head:
+            mock_head.return_value = Mock(side_effect=get_responses)
+            lgbce_review_helper = LGBCEReviewHelper()
+            self.assertEqual(
+                "https://www.legislation.gov.uk/ukdsi/2024/9780348263176/schedule/data.xml",
+                lgbce_review_helper.get_xml_link_from_eco_url(
+                    "https://www.legislation.gov.uk/ukdsi/2024/9780348263176"
+                ),
+            )
+
+    def test_get_xml_link_from_ukdsi_eco_url_c(self):
+        def get_responses(link, **kwargs):
+            """
+            The method being tested 'heads' the links generated to determine if they
+            return a 200. So we need to mock some responses.
+            """
+            mock = Mock()
+            tail = "/".join(link.split("/")[6:])
+            match tail:
+                case "schedule/1/data.xml":
+                    mock.status_code = 404
+                    return mock
+                case "schedule/data.xml":
+                    mock.status_code = 404
+                    return mock
+                case "schedules/data.xml":
+                    mock.status_code = 200
+                    return mock
+                case _:
+                    mock.status_code = 404
+                    return mock
+
+        with patch("requests.head", side_effect=get_responses) as mock_head:
+            mock_head.return_value = Mock(side_effect=get_responses)
+            lgbce_review_helper = LGBCEReviewHelper()
+            self.assertEqual(
+                "https://www.legislation.gov.uk/ukdsi/2024/9780348263176/schedules/data.xml",
+                lgbce_review_helper.get_xml_link_from_eco_url(
+                    "https://www.legislation.gov.uk/ukdsi/2024/9780348263176"
+                ),
+            )
+
     @patch("eco_parser.parser.EcoParser.get_data")
     def test_parse_eco_xml(self, get_data_mock):
         with open(

--- a/every_election/apps/organisations/models/divisions.py
+++ b/every_election/apps/organisations/models/divisions.py
@@ -286,7 +286,7 @@ class OrganisationBoundaryReview(TimeStampedModel):
     def cleaned_legislation_url(self):
         url = self.legislation_url.replace("/id/", "/")
         url = re.search(
-            r"www.legislation.gov.uk/(wsi|uksi|ssi)/\d+/\d+",
+            r"www.legislation.gov.uk/(wsi|uksi|ukdsi|ssi)/\d+/\d+",
             url,
         ).group()
         return f"https://{url}"

--- a/every_election/apps/organisations/tests/test_organisation_models.py
+++ b/every_election/apps/organisations/tests/test_organisation_models.py
@@ -326,6 +326,10 @@ class TestOrganisationDivisionBoundaryReview(TestCase):
                 "https://www.legislation.gov.uk/uksi/2021/1230/introduction/made",
                 "https://www.legislation.gov.uk/uksi/2021/1230",
             ),
+            (
+                "https://www.legislation.gov.uk/ukdsi/2024/9780348263176/contents",
+                "https://www.legislation.gov.uk/ukdsi/2024/9780348263176",
+            ),
         ]
         for raw_url, clean_url in cases:
             obr = CompletedOrganisationBoundaryReviewFactory(


### PR DESCRIPTION
I just processed the first ECO that is laid but still in 'draft' and I had to make a few changes to in order to use the handy `write_to_s3` button in the admin console:

- The `OrganizationBoundaryReview` model can now clean links that contain `ukdsi` as a subdomain
- Draft legislation pages hide their xml links differently so I've changed `get_xml_link_from_eco_url ` to handle that. I've not done a comprehensive review of xml links for draft legislation, but I'm hoping that they're won't be weirder edge cases that come up as I do more processing - we'll see.
- I've adapted existing tests to cover these cases.
