### PR TITLE
prevent elections being created when divisions have invalid territory

### DIFF
--- a/every_election/apps/elections/forms.py
+++ b/every_election/apps/elections/forms.py
@@ -225,6 +225,10 @@ class DivsFormset(forms.BaseFormSet):
                 )
 
                 for div in divisions_qs:
+                    if not div.territory_code:
+                        raise ValueError(
+                            f"Division {div} is missing territory code"
+                        )
                     kwargs["initial"].append(
                         {"division_name": div.name, "group": div.group}
                     )

--- a/every_election/apps/elections/tests/test_utils.py
+++ b/every_election/apps/elections/tests/test_utils.py
@@ -9,7 +9,7 @@ class TestGetVoterIdRequirements:
 
     @pytest.mark.parametrize(
         "territory_code,expected_result",
-        [("ENG", "EA-2022"), ("NIR", "EFA-2002"), ("", None), (None, None)],
+        [("ENG", "EA-2022"), ("NIR", "EFA-2002")],
     )
     def test_get_voter_id_requirement_expected_territory_codes(
         self, territory_code, expected_result
@@ -27,6 +27,12 @@ class TestGetVoterIdRequirements:
         election = ElectionFactory(election_id=self.default_election_id)
         with pytest.raises(ValueError):
             election.division.territory_code = "BBQ"
+            get_voter_id_requirement(election)
+
+    def test_get_voter_id_requirement_missing_territory(self):
+        election = ElectionFactory(election_id=self.default_election_id)
+        with pytest.raises(ValueError):
+            election.division.territory_code = ""
             get_voter_id_requirement(election)
 
     def test_no_divs_type_can_have_requirements(self):

--- a/every_election/apps/elections/utils.py
+++ b/every_election/apps/elections/utils.py
@@ -56,7 +56,9 @@ def get_voter_id_requirement(election: Election) -> Optional[str]:
     if can_have_divs:
         nation = election.division.territory_code
         if not nation:
-            return None
+            raise ValueError(
+                f"Division {election.division} is missing territory code"
+            )
 
     matcher = IDRequirementsMatcher(election.election_id, nation)
 


### PR DESCRIPTION
Refs https://app.asana.com/0/1204880927741389/1208865695360845/f

Currently, if a division has a missing territory code, we ignore this and silently let the user create data which is subtly wrong and will lead to us telling end users they don't need ID when they do.

Controversial opinion: This is a _bad_ thing.

The place I would like us to get to is: territory_code is a required field, and we populate it as part of the process of importing new divisions. That's quite a big job though, or at least its more than I can quickly knock out in an afternoon.

The next best thing we can do is what I've done in this PR: if someone tries to create an election ID involving a division with a missing territory_code, throw an exception. Stop them doing it. Log something to sentry. Make a dev go and fix the bad data.