### PR TITLE
Fix/allow auth headers

### DIFF
--- a/cdk_stacks/stacks/code_deploy.py
+++ b/cdk_stacks/stacks/code_deploy.py
@@ -365,21 +365,7 @@ class EECodeDeployment(Stack):
                 "/id_creator/*": cloudfront.BehaviorOptions(
                     origin=app_origin,
                     allowed_methods=cloudfront.AllowedMethods.ALLOW_ALL,
-                    origin_request_policy=cloudfront.OriginRequestPolicy(
-                        self,
-                        "origin_request_policy_id_creator",
-                        cookie_behavior=cloudfront.OriginRequestCookieBehavior.all(),
-                        header_behavior=cloudfront.OriginRequestHeaderBehavior.allow_list(
-                            "x-csrfmiddlewaretoken",
-                            "Accept",
-                            "Accept-Language",
-                            "Cache-Control",
-                            "Referer",
-                        ),
-                        query_string_behavior=cloudfront.OriginRequestQueryStringBehavior.allow_list(
-                            "reset"
-                        ),
-                    ),
+                    origin_request_policy=cloudfront.OriginRequestPolicy.ALL_VIEWER,
                     cache_policy=cloudfront.CachePolicy(
                         self,
                         "disable_cache_id_creator",

--- a/cdk_stacks/stacks/code_deploy.py
+++ b/cdk_stacks/stacks/code_deploy.py
@@ -323,6 +323,7 @@ class EECodeDeployment(Stack):
                         "x-csrfmiddlewaretoken",
                         "Accept",
                         "Accept-Language",
+                        "Authorization",
                         "Cache-Control",
                         "Referer",
                     ),
@@ -343,6 +344,9 @@ class EECodeDeployment(Stack):
                         max_ttl=Duration.days(2000),
                         enable_accept_encoding_brotli=True,
                         enable_accept_encoding_gzip=True,
+                        header_behavior=cloudfront.CacheHeaderBehavior.allow_list(
+                            "Authorization",
+                        ),
                     ),
                 ),
                 "/api/*": cloudfront.BehaviorOptions(


### PR DESCRIPTION
Dev and stage sites aren't passing the Authorization header to the CF cache and basic auth wasn't working so this fixes that. 

The `/id_creator/*` pattern doesn't use the CF cache, and I couldn't add the Authorization header to the existing custom origin request policy, so I changed it to a managed policy that allows all headers through to the origin.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208998091856562