### PR TITLE
revert ruff fix to ReadFromFileMixin

### DIFF
--- a/every_election/apps/core/mixins.py
+++ b/every_election/apps/core/mixins.py
@@ -39,8 +39,7 @@ class ReadFromFileMixin:
         )
 
     def read_from_local(self, filename):
-        with open(filename, "rt"):
-            return filename
+        return open(filename, "rt")  # noqa: SIM115
 
     def read_from_url(self, url):
         tmp = tempfile.NamedTemporaryFile()


### PR DESCRIPTION
This change made by ruff --fix in 92d7cae broke `ReadFromFileMixin` when reading local zip files. 

This is a bug with ruff that is fixed in some later versions so we can remove the noqa comment when we get around to upgrading ruff
