### PR TITLE
adds command to backport GSS codes for CEDs using ONS data

### DIFF
--- a/every_election/apps/organisations/boundaries/fixtures/ward_to_ced_county_sample.csv
+++ b/every_election/apps/organisations/boundaries/fixtures/ward_to_ced_county_sample.csv
@@ -1,0 +1,14 @@
+WD24CD,WD24NM,CED24CD,CED24NM,LAD24CD,LAD24NM,CTY24CD,CTY24NM,ObjectId
+E05013050,Abbey,E58000050,Abbey ED,E07000008,Cambridge,E10000003,Cambridgeshire,1
+E05013053,Cherry Hinton,E58000050,Abbey ED,E07000008,Cambridge,E10000003,Cambridgeshire,2
+E05013061,Romsey,E58000050,Abbey ED,E07000008,Cambridge,E10000003,Cambridgeshire,3
+E05011256,Alconbury,E58000051,Alconbury & Kimbolton ED,E07000011,Huntingdonshire,E10000003,Cambridgeshire,4
+E05011262,Great Staughton,E58000051,Alconbury & Kimbolton ED,E07000011,Huntingdonshire,E10000003,Cambridgeshire,5
+E05011267,Kimbolton,E58000051,Alconbury & Kimbolton ED,E07000011,Huntingdonshire,E10000003,Cambridgeshire,6
+E05011278,"Stilton, Folksworth & Washingley",E58000051,Alconbury & Kimbolton ED,E07000011,Huntingdonshire,E10000003,Cambridgeshire,7
+E05013051,Arbury,E58000052,Arbury ED,E07000008,Cambridge,E10000003,Cambridgeshire,8
+E05013052,Castle,E58000052,Arbury ED,E07000008,Cambridge,E10000003,Cambridgeshire,9
+E05013056,King's Hedges,E58000052,Arbury ED,E07000008,Cambridge,E10000003,Cambridgeshire,10
+E05013063,West Chesterton,E58000052,Arbury ED,E07000008,Cambridge,E10000003,Cambridgeshire,11
+E05012937,North Baddesley,E58001783,Baddesley ED,E07000093,Test Valley,E10000014,Hampshire,4471
+E05012085,Andover Downlands,E58001780,Andover North ED,E07000093,Test Valley,E10000014,Hampshire,4496

--- a/every_election/apps/organisations/boundaries/management/commands/CED_backport_GSS_codes_from_csv.py
+++ b/every_election/apps/organisations/boundaries/management/commands/CED_backport_GSS_codes_from_csv.py
@@ -1,0 +1,166 @@
+"""
+Pass in either a directory path or a download link to an ONS csv e.g.
+Ward to LAD to County to County Electoral Division (May 2024) Lookup for EN
+
+example calls:
+manage.py CED_backport_GSS_codes_from_csv -f /foo/bar/Ward_to_LAD_to_County_to_CED_(May_2024)_Lookup.csv
+manage.py boundaryline_backport_codes -u "https://hub.arcgis.com/api/v3/datasets/foo/downloads/data?format=csv&spatialRefId=bar&where=foo"
+
+"""
+
+import json
+import re
+from collections import namedtuple
+
+from core.mixins import ReadFromCSVMixin
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from organisations.boundaries.helpers import (
+    normalize_name_for_matching,
+)
+from organisations.models import OrganisationDivision
+
+
+class Command(ReadFromCSVMixin, BaseCommand):
+    help = """
+        Tries to backport GSS codes from a CSV file to the codeless CEDs in the database.
+        Defaults to current (end_date=null) CEDS that do not have gss codes.
+    """
+    Match = namedtuple("Match", ["division", "code"])
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.found = []
+        self.not_found = []
+
+    def add_arguments(self, parser):
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument(
+            "--divset-id",
+            action="store",
+            dest="divset-id",
+            help="divisionset id to match against",
+        )
+        group.add_argument(
+            "--divset-ids",
+            action="store",
+            dest="divset-ids",
+            help="local path to a JSON file containing an array of divisonset ids to match against",
+        )
+
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            dest="dry-run",
+            help="Don't commit changes",
+        )
+        super().add_arguments(parser)
+
+    def handle(self, *args, **options):
+        csv_data = self.load_data(options)
+
+        self.stdout.write("Processing csv...")
+        col_names = self.extract_col_names(csv_data)
+        lookup = self.create_csv_lookup(csv_data, col_names)
+
+        ceds = self.get_ceds_to_match(options)
+
+        self.match_db_ceds_to_csv_ceds(lookup, ceds)
+
+        if not options["dry-run"]:
+            self.save_all()
+
+        verbose = options["verbosity"] > 1
+        self.report(verbose, lookup)
+
+    def report_found(self):
+        for match in self.found:
+            self.stdout.write(
+                f"Found code {match.code} for division id: {match.division.id}"
+            )
+
+    def report_not_found(self):
+        for division in self.not_found:
+            self.stdout.write(
+                f"Could not find a code for division id: {division.id}"
+            )
+
+    def report(self, verbose, lookup):
+        self.stdout.write(
+            f"Found {len(lookup)} unique GSS codes in the input file."
+        )
+        self.stdout.write(
+            f"Searched {len(self.found) + len(self.not_found)} divisions"
+        )
+        self.stdout.write(f"Matched {len(self.found)} codes")
+        self.stdout.write("\n")
+        if verbose:
+            self.report_found()
+        self.stdout.write("\n")
+        self.report_not_found()
+
+    @transaction.atomic
+    def save_all(self):
+        self.stdout.write("Saving...")
+        for match in self.found:
+            match.division.official_identifier = match.code
+            match.division.save()
+        self.stdout.write("...done")
+
+    def match_db_ceds_to_csv_ceds(self, lookup, ceds):
+        for division in ceds:
+            division_name = division.slug
+            division_county = division.divisionset.organisation.slug
+
+            match_found = False
+
+            key = (division_name, division_county)
+            if key in lookup:
+                self.found.append(self.Match(division, f"gss:{lookup[key]}"))
+                match_found = True
+
+            if not match_found:
+                self.not_found.append(division)
+
+    def extract_col_names(self, csv_data):
+        col_names = {}
+        first_row = csv_data[0]
+        col_names["ced_name"] = self.match_col_name(first_row, r"CED\d{2}NM")
+        col_names["county_name"] = self.match_col_name(first_row, r"CTY\d{2}NM")
+        col_names["ced_gss"] = self.match_col_name(first_row, r"CED\d{2}CD")
+
+        return col_names
+
+    def match_col_name(self, data_row, col_regex):
+        match = [key for key in data_row if re.match(col_regex, key)]
+        if not match:
+            raise ValueError(f"No column found matching regex {col_regex} ")
+        if len(match) > 1:
+            raise ValueError(
+                f"Multiple columns foundmatching regex {col_regex}"
+            )
+        return match[0]
+
+    def create_csv_lookup(self, csv_data, cols):
+        lookup = {}
+        for line in csv_data:
+            ced_name = normalize_name_for_matching(line[cols["ced_name"]])
+            county_name = normalize_name_for_matching(line[cols["county_name"]])
+            ced_gss = line[cols["ced_gss"]]
+            key = (ced_name, county_name)
+            if key in lookup and lookup[key] != ced_gss:
+                raise Exception("Unexpected error in input file")
+
+            lookup[key] = ced_gss
+
+        return lookup
+
+    def get_ceds_to_match(self, options):
+        if options["divset-ids"]:
+            with open(options["divset-ids"], "r") as f:
+                divset_ids = json.load(f)
+                return self.get_ceds().filter(divisionset_id__in=divset_ids)
+        return self.get_ceds().filter(divisionset_id=options["divset-id"])
+
+    def get_ceds(self):
+        return OrganisationDivision.objects.filter(division_type="CED")

--- a/every_election/apps/organisations/boundaries/tests/test_CED_backport_codes_from_csv.py
+++ b/every_election/apps/organisations/boundaries/tests/test_CED_backport_codes_from_csv.py
@@ -1,0 +1,122 @@
+import json
+import os
+import tempfile
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+from organisations.models import (
+    OrganisationDivision,
+    OrganisationDivisionSet,
+)
+from organisations.tests.factories import (
+    OrganisationDivisionFactory,
+    OrganisationDivisionSetFactory,
+    OrganisationFactory,
+)
+
+
+def count_divs_by_prefix(prefix):
+    return (
+        OrganisationDivision.objects.all()
+        .filter(official_identifier__startswith=prefix)
+        .count()
+    )
+
+
+class CEDBackportGSSCodesTests(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.opts = {
+            "file": os.path.abspath(
+                "every_election/apps/organisations/boundaries/fixtures/ward_to_ced_county_sample.csv"
+            ),
+        }
+
+        organisation = OrganisationFactory(slug="cambridgeshire")
+        division_set = OrganisationDivisionSetFactory(organisation=organisation)
+
+        sample_divisions = [
+            "abbey",
+            "alconbury-kimbolton",
+            "arbury",
+            "bar-hill",
+        ]
+
+        for slug in sample_divisions:
+            OrganisationDivisionFactory(
+                divisionset=division_set,
+                division_type="CED",
+                official_identifier="CAM:" + slug,
+                slug=slug,
+            )
+
+    def run_command_with_test_data(self):
+        out = StringIO()
+        call_command("CED_backport_GSS_codes_from_csv", **self.opts, stdout=out)
+        return out.getvalue()
+
+    def test_backport_single_divset(self):
+        self.opts["divset-id"] = OrganisationDivisionSet.objects.first().id
+
+        output = self.run_command_with_test_data()
+        # 1 should not be found in the sample CSV
+        self.assertEqual(1, count_divs_by_prefix("CAM:"))
+        # ..and 3 should now have a GSS code
+        self.assertEqual(3, count_divs_by_prefix("gss:"))
+
+        self.assertIn("Searched 4 divisions", output)
+        self.assertIn("Matched 3 codes", output)
+        self.assertIn("Could not find a code for division", output)
+
+    def test_backport_multiple_divsets(self):
+        # Create 2nd divset for a different organisation
+        ham_divset = OrganisationDivisionSetFactory(
+            organisation=OrganisationFactory(slug="hampshire")
+        )
+        sample_divisions = ["baddesley", "andover-north"]
+
+        for slug in sample_divisions:
+            OrganisationDivisionFactory(
+                divisionset=ham_divset,
+                division_type="CED",
+                official_identifier="HAM:" + slug,
+                slug=slug,
+            )
+        # Create a temp json file with divset ids
+        divset_ids = list(
+            OrganisationDivisionSet.objects.values_list("id", flat=True)
+        )
+        tmp = tempfile.NamedTemporaryFile(suffix=".json")
+        tmp.write(json.dumps(divset_ids).encode())
+        tmp.seek(0)
+        self.opts["divset-ids"] = tmp.name
+        output = self.run_command_with_test_data()
+        tmp.close()
+
+        # 1 should not be found in the sample CSV
+        self.assertEqual(
+            1, count_divs_by_prefix("HAM:") + count_divs_by_prefix("CAM:")
+        )
+        # ..and 5 should now have a GSS code
+        self.assertEqual(5, count_divs_by_prefix("gss:"))
+
+        self.assertIn("Searched 6 divisions", output)
+        self.assertIn("Matched 5 codes", output)
+        self.assertIn("Could not find a code for division", output)
+
+    def test_dry_run(self):
+        self.opts["dry-run"] = True
+        self.opts["divset-id"] = OrganisationDivisionSet.objects.first().id
+
+        output = self.run_command_with_test_data()
+
+        # database content should not have changed
+        self.assertEqual(4, count_divs_by_prefix("CAM:"))
+        self.assertEqual(0, count_divs_by_prefix("gss:"))
+
+        # but we should still output info on the console
+        self.assertIn("Searched 4 divisions", output)
+        self.assertIn("Matched 3 codes", output)
+        self.assertIn("Could not find a code for division", output)


### PR DESCRIPTION
This PR adds a management command that backports CED gss codes from ONS csv lookups e.g. https://geoportal.statistics.gov.uk/datasets/2dd3a997bd87443fa098deb797375610_0/explore

Because CED names aren't unique, it tries to match db CED records on CED name and County name to the csv records. THe command defaults to trying to match current CEDs (i.e. in divisionsets that don't have an end date and who have already started) without gss codes. 

I've included a few optional flags as well:
- `--dry-run` - for testing
- `--include-end-date` will include any CEDs in divisionsets with the given end-date This is mainly so I can easily include the divisionsets in light green on [this list](https://docs.google.com/spreadsheets/d/1drDl7QYP4r6VpTfcXisH2qCIQZU3VM3bnd1u3rfaYM0/edit?usp=sharing).
- `--end-date-only` - will only try any CEDs in divisionsets with the given end-date. I figured if I was implementing the above flag, I might as well add something like this too, in case we want to go back any further than discussed with our backporting.

### Testing:
I chose not to end up writing any unit tests because no individual function felt that important - but happy to revisit if you disagree.

to run new tests:
```bash
pytest every_election/apps/organisations/boundaries/tests/test_CED_backport_codes_from_csv.py
```
Example command for running locally:
```bash
python manage.py CED_backport_GSS_codes_from_csv -f /path/to/lookup/file.csv --include-end-date 2025-04-30 --dry-run 
```
Link to dataset: https://geoportal.statistics.gov.uk/datasets/2dd3a997bd87443fa098deb797375610_0/explore


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209157822204375**
