### PR TITLE
adapt boundaryline_import_boundaries to import CED boundaries

### DIFF
--- a/every_election/apps/organisations/boundaries/helpers.py
+++ b/every_election/apps/organisations/boundaries/helpers.py
@@ -20,6 +20,8 @@ def normalize_name_for_matching(name):
         return slug[:-3]
     if slug.endswith("-ward"):
         return slug[:-5]
+    if slug.endswith("-county"):
+        return slug[:-7]
     return slug
 
 

--- a/every_election/apps/organisations/boundaries/tests/test_helpers.py
+++ b/every_election/apps/organisations/boundaries/tests/test_helpers.py
@@ -17,6 +17,10 @@ class NormalizeNamesTest(TestCase):
             normalize_name_for_matching("St. Helen's"),
         )
         self.assertEqual(
+            normalize_name_for_matching("CAMBRIDGESHIRE-COUNTY"),
+            normalize_name_for_matching("CAMBRIDGESHIRE"),
+        )
+        self.assertEqual(
             normalize_name_for_matching("St. Helens"),
             normalize_name_for_matching("St Helen's"),
         )


### PR DESCRIPTION
Adapts `boundaryline_import_boundaries` to import CED boundaries by matching against name and county rather than GSS code.

### Testing:

Set GSS code for a CED in admin ([source](https://geoportal.statistics.gov.uk/datasets/2dd3a997bd87443fa098deb797375610_0/explore)) and run the command using that code (you could also use the command described in https://github.com/DemocracyClub/EveryElection/wiki/Backporting-CED-codes to backport the codes for a county).


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209157822204376