### PR TITLE
Limit the number of results it's possible to return in API requests

### DIFF
--- a/every_election/apps/api/tests/test_api_election_endpoint.py
+++ b/every_election/apps/api/tests/test_api_election_endpoint.py
@@ -580,3 +580,18 @@ class TestElectionAPIQueries(APITestCase):
             {"overlaps", "same", "contains", "within"},
             {e["election_title"] for e in data["results"]},
         )
+
+    def test_max_limit(self):
+        """
+        We want to prevent users adding e.g limit=100000 to API calls.
+
+        Test that marge values are capped in MaxSizeLimitOffsetPagination
+        """
+
+        # Making elections is expensive, so let's only make what we need to
+        # test that everything is working
+        ElectionWithStatusFactory.create_batch(102)
+        resp = self.client.get("/api/elections/?limit=100000")
+        resp_json = resp.json()
+        self.assertEqual(len(resp_json["results"]), 100)
+        self.assertEqual(resp_json["count"], 102)

--- a/every_election/apps/core/helpers.py
+++ b/every_election/apps/core/helpers.py
@@ -1,4 +1,6 @@
+from django.conf import settings
 from django.contrib.auth.models import Group, User
+from rest_framework.pagination import LimitOffsetPagination
 
 
 def user_is_moderator(user: User):
@@ -6,3 +8,7 @@ def user_is_moderator(user: User):
         return False
     group = Group.objects.get(name="moderators")
     return group in user.groups.all()
+
+
+class MaxSizeLimitOffsetPagination(LimitOffsetPagination):
+    max_limit = getattr(settings, "API_MAX_LIMIT", 100)

--- a/every_election/settings/base.py
+++ b/every_election/settings/base.py
@@ -261,7 +261,7 @@ LOGIN_REDIRECT_URL = "home"
 LOGOUT_REDIRECT_URL = "home"
 
 REST_FRAMEWORK = {
-    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
+    "DEFAULT_PAGINATION_CLASS": "core.helpers.MaxSizeLimitOffsetPagination",
     "PAGE_SIZE": 100,
     "DEFAULT_FILTER_BACKENDS": (
         "django_filters.rest_framework.DjangoFilterBackend",
@@ -272,6 +272,7 @@ REST_FRAMEWORK = {
         "rest_framework_jsonp.renderers.JSONPRenderer",
     ),
 }
+API_MAX_LIMIT = 100
 
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_URLS_REGEX = r"^/api/.*$"
@@ -313,7 +314,6 @@ if not os.environ.get("DC_ENVIRONMENT") and DEBUG_TOOLBAR:
     MIDDLEWARE = [
         "debug_toolbar.middleware.DebugToolbarMiddleware",
     ] + MIDDLEWARE
-
 
 # importing test settings file if necessary
 if IN_TESTING:


### PR DESCRIPTION
This prevents someone calling ?limit=100000 and DoSing the server
