### PR TITLE
remove duplicated org problems in admin

### DIFF
--- a/every_election/apps/organisations/models/admin.py
+++ b/every_election/apps/organisations/models/admin.py
@@ -117,7 +117,7 @@ class OrganisationProblemManager(Manager):
                 # one related ElectedRole record
                 Q(electedrole=None)
             )
-        )
+        ).distinct()
 
 
 class OrganisationProblem(Organisation):


### PR DESCRIPTION
remove duplicated org problems in admin by add `.distinct()` to the end of the query. 