### PR TITLE
boundary bot ignore plymouth

### DIFF
--- a/every_election/apps/organisations/boundaries/boundary_bot/scraper.py
+++ b/every_election/apps/organisations/boundaries/boundary_bot/scraper.py
@@ -67,6 +67,7 @@ class LgbceScraper:
         self.SEND_NOTIFICATIONS = SEND_NOTIFICATIONS
         self.ignore = [
             # orgs that break our pipeline can be ignored here
+            "plymouth",  # https://www.lgbce.org.uk/all-reviews/plymouth is a breaking edge case that because of devolution atm so we'll ignore it for now
         ]
 
     def scrape_index(self):


### PR DESCRIPTION
Ignore plymouth because it's currently got a unique message on its lgbce page that is breaking the scraper. I've made a card to check the page in a month and see if its changed.