### PR TITLE
add bulk cancel command

### DIFF
--- a/every_election/apps/elections/management/commands/bulk_cancel.py
+++ b/every_election/apps/elections/management/commands/bulk_cancel.py
@@ -1,0 +1,45 @@
+from django.core.management import BaseCommand
+from elections.models import Election, MetaData
+
+
+class Command(BaseCommand):
+    help = """
+    This command cancels a given election and any descendents.
+
+    Example usage:
+    python manage.py bulk_cancel local.essex.2025-05-01
+    python manage.py bulk_cancel local.essex.2025-05-01 --metadata-id 50
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "election",
+            type=str,
+            help="Election to cancel. Specifying an election group or organisation group will cancel all child ballots",
+        )
+        parser.add_argument(
+            "--metadata-id",
+            action="store",
+            type=int,
+            help="ID of a metadata object to attach to the elections we are cancelling",
+            required=False,
+        )
+
+    def handle(self, *args, **options):
+        election_id = options["election"]
+
+        elections = (
+            Election.public_objects.get(election_id=election_id)
+            .get_descendents("public_objects", inclusive=True)
+            .order_by("election_id")
+        )
+        self.stdout.write(f"updating {elections.count()} elections..")
+        for election in elections:
+            self.stdout.write(f"updating {election.election_id}..")
+            election.cancelled = True
+            if options.get("metadata_id"):
+                election.metadata = MetaData.objects.get(
+                    pk=options["metadata_id"]
+                )
+            election.save()
+        self.stdout.write("..done!")

--- a/every_election/apps/elections/management/commands/bulk_cancel.py
+++ b/every_election/apps/elections/management/commands/bulk_cancel.py
@@ -1,4 +1,5 @@
 from django.core.management import BaseCommand
+from django.db import transaction
 from elections.models import Election, MetaData
 
 
@@ -35,11 +36,15 @@ class Command(BaseCommand):
         )
         self.stdout.write(f"updating {elections.count()} elections..")
         for election in elections:
-            self.stdout.write(f"updating {election.election_id}..")
             election.cancelled = True
             if options.get("metadata_id"):
                 election.metadata = MetaData.objects.get(
                     pk=options["metadata_id"]
                 )
-            election.save()
+
+        with transaction.atomic():
+            for election in elections:
+                self.stdout.write(f"updating {election.election_id}..")
+                election.save()
+
         self.stdout.write("..done!")


### PR DESCRIPTION
This command allows us to call something like

```
python manage.py bulk_cancel local.essex.2025-05-01
```

to cancel a group and all of its child ballots.

We can also optionally pass a `metadata-id` param

```
python manage.py bulk_cancel local.essex.2025-05-01 --metadata-id 50
```

This allows us to efficiently process all the cancellations we need to do today. Ideally I'd have done this via the admin, but a management command was quick and we need it this afternoon.