### PR TITLE
Check if identified type passed before prefetching

### DIFF
--- a/every_election/apps/api/tests/test_api_election_endpoint.py
+++ b/every_election/apps/api/tests/test_api_election_endpoint.py
@@ -76,7 +76,7 @@ class TestElectionAPIQueries(APITestCase):
         ElectionWithStatusFactory(group=None, division_geography=None)
 
         # we should monitor this and be aware if this number increases
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             resp = self.client.get("/api/elections/?postcode=SW1A1AA")
 
         data = resp.json()
@@ -211,6 +211,11 @@ class TestElectionAPIQueries(APITestCase):
     def test_detail_invalid_id(self):
         resp = self.client.get("/api/elections/foo/")
         self.assertEqual(400, resp.status_code)
+
+    def test_detail_num_queries(self):
+        id_ = ElectionWithStatusFactory(group=None).election_id
+        with self.assertNumQueries(2):
+            self.client.get(f"/api/elections/{id_}/")
 
     def test_identifier_type_filter(self):
         group = ElectionWithStatusFactory(

--- a/every_election/apps/api/views.py
+++ b/every_election/apps/api/views.py
@@ -89,7 +89,7 @@ class ElectionViewSet(viewsets.ReadOnlyModelViewSet):
             identifier_type = self.request.query_params.get(
                 "identifier_type", None
             )
-            if identifier_type != "ballot":
+            if identifier_type and identifier_type != "ballot":
                 queryset = queryset.prefetch_related(
                     Prefetch("_children_qs", Election.public_objects.all())
                 )


### PR DESCRIPTION
This saves a query when requesting a single ballot
