### PR TITLE
serve a Last-Modified header on election detail endpoint

### DIFF
--- a/every_election/apps/api/tests/test_api_election_endpoint.py
+++ b/every_election/apps/api/tests/test_api_election_endpoint.py
@@ -214,7 +214,7 @@ class TestElectionAPIQueries(APITestCase):
 
     def test_detail_num_queries(self):
         id_ = ElectionWithStatusFactory(group=None).election_id
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             self.client.get(f"/api/elections/{id_}/")
 
     def test_identifier_type_filter(self):


### PR DESCRIPTION
Refs
https://app.asana.com/0/1204880927741389/1209455180573671
https://app.asana.com/0/1204880927741389/1209455180573673

In this PR, I have worked on an improved version of the quick code in
https://app.asana.com/0/0/1209455180573673/1209508193329969/f
It is the same concept, but I've fixed some things.

A couple of things I have learned from testing this on CloudFront:

We don't need to change any CloudFront config to tell it to send a `If-Modified-Since request` header. It will send one if the cached object had a `Last-Modified` header on it, so sending that header on responses (which happens if `single_ballot_cache()` returns anything other than `None`) automatically configures the behaviour we want from the CDN.
It is also worth noting that browsers also do this.

If the origin returns a 304, we get a `x-cache: RefreshHit from cloudfront` header on the response instead of a `x-cache: Hit from cloudfront` which is useful for debugging purposes.