### PR TITLE
Fix sync_map_layers_to_s3.sh path

### DIFF
--- a/serverscripts/sync_map_layers_to_s3.sh
+++ b/serverscripts/sync_map_layers_to_s3.sh
@@ -6,5 +6,5 @@ mkdir -p $MAP_DATA_PATH
 
 ee-manage-py-command export_boundaries --output $MAP_DATA_PATH
 
-aws s3 sync $MAP_DATA_PATH s3://ee-maps/ --acl public-read --content-type "application/json"
+aws s3 sync $MAP_DATA_PATH s3://ee.public.data/ee-maps/ --acl public-read --content-type "application/json"
 rm $MAP_DATA_PATH/*


### PR DESCRIPTION
The old `ee-maps` bucket is in the old AWS account. 

This one is in the new account, so probably makes sense to use it.
