### PR TITLE
scale up infra

### DIFF
--- a/cdk_stacks/stacks/code_deploy.py
+++ b/cdk_stacks/stacks/code_deploy.py
@@ -74,10 +74,18 @@ class EECodeDeployment(Stack):
         security_group: ec2.SecurityGroup,
         role: iam.Role,
     ) -> ec2.LaunchTemplate:
+        instance_types_per_env = {
+            "development": "t3a.medium",
+            "staging": "t3a.medium",
+            # "production": "t3a.medium",
+            "production": "c6a.2xlarge",
+        }
         return ec2.LaunchTemplate(
             self,
             "ee-launch-template-id",
-            instance_type=ec2.InstanceType("t3a.medium"),
+            instance_type=ec2.InstanceType(
+                instance_types_per_env.get(self.dc_environment)
+            ),
             machine_image=ami,
             launch_template_name="ee-launch-template",
             role=role,

--- a/deployscripts/create_deployment_group.py
+++ b/deployscripts/create_deployment_group.py
@@ -94,6 +94,15 @@ def create_default_asg():
     ]
     if "default" in existing_asgs:
         return None
+
+    min_size = 1
+    max_size = 1
+    desired_capacity = 1
+    if os.environ.get("DC_ENVIRONMENT") == "production":
+        min_size = 2
+        max_size = 8
+        desired_capacity = 2
+
     return client.create_auto_scaling_group(
         AutoScalingGroupName="default",
         AvailabilityZones=[
@@ -105,9 +114,9 @@ def create_default_asg():
             "LaunchTemplateName": "ee-launch-template",
             "Version": "$Latest",
         },
-        MinSize=1,
-        MaxSize=1,
-        DesiredCapacity=1,
+        MinSize=min_size,
+        MaxSize=max_size,
+        DesiredCapacity=desired_capacity,
         HealthCheckType="ELB",
         HealthCheckGracePeriod=300,
         TargetGroupARNs=[target_group_arn],


### PR DESCRIPTION
To be merged next week

From Tuesday next week lets move up to 2x `c6a.2xlarge` instances in prod. I'll review again ahead of polling day

I've also copied some code in here for allowing us to have different configs for prod/staging/dev