### PR TITLE
specify min generation on mapit links if division is not current

### DIFF
--- a/every_election/apps/organisations/models/divisions.py
+++ b/every_election/apps/organisations/models/divisions.py
@@ -162,7 +162,11 @@ class OrganisationDivision(UpdateElectionsTimestampedModel):
         if code_type.lower() != "gss":
             return None
 
-        return "https://mapit.mysociety.org/area/{}".format(code)
+        link = f"https://mapit.mysociety.org/area/{code}.html"
+        if self.divisionset.end_date:
+            link += "?min_generation=1"
+
+        return link
 
 
 class DivisionGeography(models.Model):

--- a/every_election/apps/organisations/models/organisations.py
+++ b/every_election/apps/organisations/models/organisations.py
@@ -103,7 +103,7 @@ class Organisation(UpdateElectionsTimestampedModel, DateDisplayMixin):
             return None
         if not self.geographies.latest().gss:
             return None
-        return "https://mapit.mysociety.org/area/{}".format(
+        return "https://mapit.mysociety.org/area/{}.html".format(
             self.geographies.latest().gss
         )
 

--- a/every_election/apps/organisations/templates/organisations/organisation_detail.html
+++ b/every_election/apps/organisations/templates/organisations/organisation_detail.html
@@ -49,7 +49,7 @@
                                         <td>{{ division.division_subtype }}</td>
                                         <td>
                                             {% if division.format_geography_link %}
-                                                <a href="{{ division.format_geography_link }}.html">
+                                                <a href="{{ division.format_geography_link }}">
                                                     {{ division.official_identifier }}
                                                 </a>
                                             {% else %}

--- a/every_election/apps/organisations/tests/test_organisation_models.py
+++ b/every_election/apps/organisations/tests/test_organisation_models.py
@@ -100,7 +100,7 @@ class TestOrganisationGeographies(TestCase):
             geo, org.get_geography("doesn't even need to be a date")
         )
         self.assertEqual(
-            "https://mapit.mysociety.org/area/X01000001",
+            "https://mapit.mysociety.org/area/X01000001.html",
             org.format_geography_link(),
         )
         geo.gss = ""
@@ -193,7 +193,7 @@ class TestOrganisationDivision(TestCase):
 
     def test_format_geography_valid(self):
         self.assertEqual(
-            "https://mapit.mysociety.org/area/X01000001",
+            "https://mapit.mysociety.org/area/X01000001.html?min_generation=1",
             OrganisationDivisionFactory(
                 official_identifier="gss:X01000001"
             ).format_geography_link(),


### PR DESCRIPTION
Refs https://github.com/mysociety/mapit/issues/433

It used to be that you could call `/area/<gss>` with any GSS code and it would search for that GSS code, even if that GSS code was not active in the current generation.

Mapit made a change upstream which means this is no longer true. This means a lot of our mapit links for old geographies are broken.

Adding `min_generation=1` effectively restores the previous behaviour of searching across genenerations with the caveat that there may still be some GSS codes that will give a 404 because mapit has duplicates for some GSS codes. Annoyingly current Westminster Constituencies are one of those cases so we also don't want to just _always_ pass `min_generation=1`. Doing that causes other problems.

The change in this PR should fix _most_ of our links out to mapit. Maybe not 100% of them. It should also not break any that currently work. That said, I think there is a good case for just making our own maps and providing good maps for orgs/divisions/division sets like we do for election objects. We have the polygons to do it, and this would cover other cases (e.g: where we hold divisions that aren't in BoundaryLine yet). Even if we do that, linking out to mapit where we can is still a useful feature to retain IMO.

Refs https://app.asana.com/1/1204880536137786/project/1207880534533137/task/1210054691908446?focus=true