### PR TITLE
improve name mapping

### DIFF
--- a/every_election/apps/organisations/importers.py
+++ b/every_election/apps/organisations/importers.py
@@ -71,24 +71,38 @@ class DivisionSetGeographyImporter:
         if settings.IN_TESTING:
             return None
 
-        legislation_names = set(legislation_names)
-        boundary_names = set(boundary_names)
+        # We want to remove common suffixes from the boundary names before comparing to legislation names,
+        # but we want to use the original names in the name map so we build a stripped-orig mapping
+        stripped_to_original = self.make_stripped_suffixes_map(boundary_names)
 
-        missing_from_leg = sorted(boundary_names - legislation_names)
-        map = {}
-        for name in sorted(legislation_names):
-            if name not in boundary_names:
+        # We start the name_map by adding all the names that had a suffix stripped successfully
+        name_map = {
+            orig: stripped
+            for stripped, orig in stripped_to_original.items()
+            if stripped != orig
+        }
+
+        # Then we compare the legislation names to stripped names, if any don't match we prompt the user
+        legislation_names = set(legislation_names)
+        stripped_boundary_names = set(stripped_to_original.keys())
+
+        missing_from_leg = sorted(stripped_boundary_names - legislation_names)
+
+        for leg_name in sorted(legislation_names):
+            if leg_name not in stripped_boundary_names:
                 self.stdout.write(
                     inspect.cleandoc(
                         f"""Legislation is expecting a division called
-                    \t{name}
+                    \t{leg_name}
                     but that doesn't exist in the boundary data
                     Might it be one of these?
                     """
                     )
                 )
                 for i, missing_name in enumerate(missing_from_leg, start=1):
-                    self.stdout.write(f"\t {i}. {missing_name}")
+                    self.stdout.write(
+                        f"\t {i}. {stripped_to_original[missing_name]}"
+                    )
                 match = None
                 while not match:
                     match = input(
@@ -102,11 +116,31 @@ class DivisionSetGeographyImporter:
 
                 if match != "s":
                     matched_name = missing_from_leg.pop(match - 1)
+                    original_name = stripped_to_original[matched_name]
                     self.stdout.write(
-                        f"Asserting that {name} is the same as {matched_name}"
+                        f"Asserting that {leg_name} is the same as {original_name}"
                     )
-                    map[matched_name] = name
-        return map
+                    name_map[original_name] = leg_name
+        return name_map
+
+    def make_stripped_suffixes_map(self, boundary_names):
+        """
+        Creates a mapping from boundary names with common suffixes removed to their original names.
+        """
+        stripped_to_original = {}
+        for name in boundary_names:
+            stripped = self.remove_common_suffixes(name)
+            stripped_to_original[stripped] = name
+        return stripped_to_original
+
+    def remove_common_suffixes(self, name):
+        suffixes = [" Electoral Division", " ED", " Division", " Ward"]
+        suffixes = suffixes + [s.lower() for s in suffixes]
+
+        for suffix in suffixes:
+            name = name.removesuffix(suffix)
+
+        return name
 
     def check_names(self):
         legislation_names = sorted(


### PR DESCRIPTION
This PR makes it so that the `DivisionSetGeographyImporter` strips common suffixes off mapping file division names before trying to match them with the legislation names.

It should reduce the amount of division name mismatches we encounter when importing LGBCE boundary reviews and therefore reduce the potential for human error when generating name maps.


Tested by running through importing the Shropshire 2024 ECO locally. This was a good test because:
1) I made the North/North East mistake on this one before and now that isn't possible because those divisions no longer appear on the mismatch list.
2) You still need to go through the name_map.json generation process, but it's a much smaller list and they're all due to spelling mistakes in the mapping file.

There are likely more suffixes that will need to be added as we encounter them.
 