### PR TITLE
don't cache moderation/review pages

### DIFF
--- a/every_election/apps/election_snooper/views/bot_review.py
+++ b/every_election/apps/election_snooper/views/bot_review.py
@@ -5,6 +5,8 @@ from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.http import HttpResponseRedirect
 from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import never_cache
 from django.views.generic import TemplateView
 from election_snooper.forms import ReviewElectionForm
 from election_snooper.models import SnoopedElection
@@ -12,6 +14,10 @@ from election_snooper.models import SnoopedElection
 
 class SnoopedElectionView(UserPassesTestMixin, TemplateView):
     template_name = "election_snooper/snooped_election_list.html"
+
+    @method_decorator(never_cache)
+    def dispatch(self, *args, **kwargs):
+        return super().dispatch(*args, **kwargs)
 
     def test_func(self):
         return user_is_moderator(self.request.user)

--- a/every_election/apps/election_snooper/views/human_review.py
+++ b/every_election/apps/election_snooper/views/human_review.py
@@ -3,6 +3,8 @@ from django.contrib.auth.mixins import UserPassesTestMixin
 from django.db import transaction
 from django.http import HttpResponseRedirect
 from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import never_cache
 from django.views.generic import TemplateView
 from election_snooper.forms import ModerationHistoryForm
 from elections.constraints import check_constraints, has_approved_parents
@@ -18,6 +20,10 @@ def set_election_status(election, status, user):
 
 class ModerationQueueView(UserPassesTestMixin, TemplateView):
     template_name = "election_snooper/moderation_queue.html"
+
+    @method_decorator(never_cache)
+    def dispatch(self, *args, **kwargs):
+        return super().dispatch(*args, **kwargs)
 
     def test_func(self):
         return user_is_moderator(self.request.user)


### PR DESCRIPTION
Refs https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1210436446762455?focus=true

This fixes a long-standing bug: The lists of elections to be moderated are cached at the CDN. This means you approve one, go back to the list, and the one you just approved is still there.

In this PR I'm using the [never_cache](https://docs.djangoproject.com/en/5.2/topics/http/decorators/#django.views.decorators.cache.never_cache) decorator to send a cache-control header instructing browsers and proxies not to cache these pages. Given these are only shown to logged in users (so about 10 people) the performance impact will be negligible. I don't see a reason to do anything more complicated.