### PR TITLE
remove api text from home page

### DIFF
--- a/every_election/templates/home.html
+++ b/every_election/templates/home.html
@@ -26,15 +26,6 @@
 
             <h3>Heard about a new election?</h3>
             <a href="{% url "id_creator" %}" class="ds-cta">Add a new election</a>
-
-
-
-            <h3>The data is open to all</h3>
-            <p><a href="{% url "api:api-root" %}">We are building an API</a> that you can start using.
-                It's very new and will change a bit, so it's best
-                to <a href="https://democracyclub.org.uk/contact/">get in touch</a>
-                if you're interested in using that data.</p>
-
         </div>
     </section>
 {% endblock content %}


### PR DESCRIPTION
Lets delete this text.
For one thing, this API is approaching its 10th birthday
For another, we've decided we don't really want people to use it directly