### PR TITLE
Split BeforeInstall hook into two

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -63,8 +63,12 @@ hooks:
 #   revision's file bundle.
 # During the BeforeInstall deployment lifecycle event, run the commands
 #   in the script specified in "location".
-  BeforeInstall:
+  ApplicationStop:
     - location: deployscripts/stop_application.sh
+      timeout: 300
+      runas: root
+  BeforeInstall:
+    - location: deployscripts/before_install.sh
       timeout: 300
       runas: root
   #   - location:

--- a/deployscripts/before_install.sh
+++ b/deployscripts/before_install.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -xeE
+
+# delete all code including hidden files
+rm -rf /var/www/every_election/repo/* /var/www/every_election/repo/.* 2> /dev/null || true

--- a/deployscripts/stop_application.sh
+++ b/deployscripts/stop_application.sh
@@ -2,6 +2,3 @@
 set -xeE
 
 service gunicorn_every_election stop
-
-# delete all code including hidden files
-rm -rf /var/www/every_election/repo/* /var/www/every_election/repo/.* 2> /dev/null || true


### PR DESCRIPTION
We need to get the service stop command into the application stop hook so that if it fails, we don't fail the deploy. This is a precursor to swapping out the base image for one that doesn't have the ee service on it. This is a little confusing becuase we were running a script called `stop_application.sh` in the beforeinstall hook.