### PR TITLE
fix searching for elections in admin

### DIFF
--- a/every_election/apps/elections/admin.py
+++ b/every_election/apps/elections/admin.py
@@ -37,6 +37,9 @@ class GroupTypeListFilter(admin.SimpleListFilter):
         ]
 
     def queryset(self, request, queryset):
+        if self.value() is None:
+            return queryset
+
         if self.value() == "ballot":
             return queryset.filter(
                 group_type=None,


### PR DESCRIPTION
Fix for https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1211099490497607?focus=true

This fixes a bug in `GroupTypeListFilter` that was causing us to filter only `group_type=None` (i.e: elections of type "ballot") when `self.value()` was `None`