### PR TITLE
Feat/multi div type pmtiles

### DIFF
--- a/every_election/apps/organisations/pmtiles_creator.py
+++ b/every_election/apps/organisations/pmtiles_creator.py
@@ -1,36 +1,39 @@
 import subprocess
 
+import psycopg2
 from django.db import connection
 from organisations.models import DivisionGeography
 
 
 class PMtilesCreator:
     def __init__(self, divset):
-        div_subtypes = divset.divisions.values("division_subtype").distinct()
-        if div_subtypes.count() > 1:
-            raise NotImplementedError(
-                "PMTiles creation is not implemented for multiple division subtypes."
-            )
         self.divset = divset
 
     def create_pmtile(self, dest_dir):
         pmtiles_fp = f"{dest_dir}/{self.divset.pmtiles_file_name}"
+        # Create a geojson file for each division subtype
+        div_types = set(
+            self.divset.divisions.values_list("division_type", flat=True)
+        )
+        geojson_files = []
+        for div_type in div_types:
+            geojson_fp = self.create_geojson(dest_dir, div_type)
+            geojson_files.append(geojson_fp)
 
-        geojson_fp = self.create_geojson(dest_dir)
-        tippecanoe_command = f"tippecanoe -o {pmtiles_fp} -zg --drop-rate=2 --drop-densest-as-needed {geojson_fp} -l {self.divset.id}"
+        tippecanoe_command = f"tippecanoe -o {pmtiles_fp} -zg --drop-rate=2 --drop-densest-as-needed {' '.join(geojson_files)}"
         subprocess.run(tippecanoe_command, shell=True, check=True)
 
         return pmtiles_fp
 
-    def create_geojson(self, dest_dir):
-        geojson_fp = f"{dest_dir}/{self.divset.id}.geojson"
-        ogr_command = self.construct_ogr_command(geojson_fp)
+    def create_geojson(self, dest_dir, div_type):
+        geojson_fp = f"{dest_dir}/{self.divset.id}_{div_type}.geojson"
+        ogr_command = self.construct_ogr_command(geojson_fp, div_type)
         subprocess.run(ogr_command, shell=True, check=True)
         return geojson_fp
 
-    def construct_ogr_command(self, geojson_fp):
+    def construct_ogr_command(self, geojson_fp, div_type):
         db_settings = connection.settings_dict
-        sql_query = self.construct_sql_query(self.divset.id)
+        sql_query = self.construct_sql_query(self.divset.id, div_type)
 
         db_connection_string = (
             f"dbname={db_settings['NAME']} "
@@ -46,10 +49,11 @@ class PMtilesCreator:
             f'-sql "{sql_query}"'
         )
 
-    def construct_sql_query(self, divisionset_id):
+    def construct_sql_query(self, divisionset_id, div_type):
         sql, params = (
             DivisionGeography.objects.filter(
-                division__divisionset_id=divisionset_id
+                division__divisionset_id=divisionset_id,
+                division__division_type=div_type,
             )
             .select_related("division")
             .values(
@@ -62,5 +66,14 @@ class PMtilesCreator:
             )
             .query.sql_with_params()
         )
+
         sql = sql.replace("::bytea", "")  # Remove bytea typecast
-        return sql % params  # Substitute parameters into the SQL query
+
+        # Format params for SQL
+        formatted_params = tuple(
+            psycopg2.extensions.adapt(p).getquoted().decode()
+            if isinstance(p, str)
+            else p
+            for p in params
+        )
+        return sql % formatted_params  # Substitute params into the SQL query

--- a/every_election/apps/organisations/templates/organisations/divisionset_map.html
+++ b/every_election/apps/organisations/templates/organisations/divisionset_map.html
@@ -3,6 +3,47 @@
 
 {% block extra_site_css %}
     {% stylesheet 'maplibre-gl' %}
+    <style>
+        #map-toggle-menu {
+            background: #fff;
+            position: absolute;
+            z-index: 1;
+            top: 10px;
+            left: 10px;
+            border-radius: 3px;
+            width: 100px;
+            border: 1px solid rgba(0, 0, 0, 0.4);
+            display: none;
+        }
+
+        #map-toggle-menu a {
+            font-size: 13px;
+            color: #404040;
+            display: block;
+            padding: 5px;
+            text-decoration: none;
+            border-bottom: 1px solid rgba(0, 0, 0, 0.25);
+            text-align: center;
+        }
+
+        #map-toggle-menu a:last-child {
+            border: none;
+        }
+
+        #map-toggle-menu a:hover {
+            background-color: #f8f8f8;
+            color: #404040;
+        }
+
+        #map-toggle-menu a.active {
+            background-color: #3887be;
+            color: #ffffff;
+        }
+
+        #map-toggle-menu a.active:hover {
+            background: #3074a4;
+        }
+    </style>
 {% endblock extra_site_css %}
 
 {% block extra_site_javascript %}
@@ -12,16 +53,20 @@
 
 <div >
     <h3>Map</h3>
-    <div id="maplibre-gl" class="ds-map-leaflet"></div>
+    <div id="maplibre-gl" class="ds-map-leaflet">
+        <nav id="map-toggle-menu"></nav>
+    </div>
 </div>
 
 
 {% block in_page_javascript %}
     {{ pmtiles_source_link|json_script:"pmtilesSourceLink" }}
+    {{ map_layer_display_name_mapping|json_script:"mapLayerDisplayNameMapping" }}
 
     <script>
         document.addEventListener("DOMContentLoaded", function() {
             const pmtilesSourceLink = JSON.parse(document.getElementById('pmtilesSourceLink').textContent);
+            const mapLayerDisplayNameMapping = JSON.parse(document.getElementById('mapLayerDisplayNameMapping').textContent);
 
             let protocol = new pmtiles.Protocol();
             maplibregl.addProtocol('pmtiles', protocol.tile);
@@ -100,6 +145,78 @@
                         [boundsArray[2], boundsArray[3]]
                     ], {linear: false, duration: 0, padding: 50})
                 });
+
+                map.on('idle', () => {
+                    // return early if 1 or less layer
+                    if (data.vector_layers.length < 2) {
+                        return;
+                    }
+                    // Show the toggle menu
+                    document.getElementById('map-toggle-menu').style.display = 'block';
+
+                    const toggleableLayerIds = data.vector_layers.map(layer => layer.id);
+
+                    // Set up toggle button for each layer.
+                    toggleableLayerIds.forEach((layerID, layerIDx) => {
+                        // Skip layers that already have a button set up.
+                        if (document.getElementById(layerID)) {
+                            return;
+                        }
+
+                        function getLayerDisplayName(divisionType) {
+                            if (mapLayerDisplayNameMapping[divisionType]) {
+                                return mapLayerDisplayNameMapping[divisionType];
+                            }
+                            return divisionType;
+                        };
+
+                        const divisionType = layerID.slice(-3)
+                        const linkContent = getLayerDisplayName(divisionType)
+
+                        // Create a link.
+                        const link = document.createElement('a');
+                        link.id = layerID;
+                        link.href = '#';
+                        link.textContent = linkContent;
+                        link.className = layerIDx === 0 ? 'active' : '';
+
+                        // Set initial visibility: only first layer is visible
+                        const fillLayer = `${layerID}-fill`;
+                        const lineLayer = `${layerID}-line`;
+                        if (layerIDx === 0) {
+                            map.setLayoutProperty(fillLayer, 'visibility', 'visible');
+                            map.setLayoutProperty(lineLayer, 'visibility', 'visible');
+                        } else {
+                            map.setLayoutProperty(fillLayer, 'visibility', 'none');
+                            map.setLayoutProperty(lineLayer, 'visibility', 'none');
+                        }
+
+                        link.onclick = function (e) {
+                            const clickedIDFillLayer = `${this.id}-fill`;
+                            const clickedIDLineLayer = `${this.id}-line`;
+                            e.preventDefault();
+                            e.stopPropagation();
+
+                            const fillVisibility = map.getLayoutProperty(clickedIDFillLayer, 'visibility');
+                            const lineVisibility = map.getLayoutProperty(clickedIDLineLayer, 'visibility');
+
+                            // Toggle both fill and line layer visibility
+                            if (fillVisibility === 'visible' || lineVisibility === 'visible') {
+                                map.setLayoutProperty(clickedIDFillLayer, 'visibility', 'none');
+                                map.setLayoutProperty(clickedIDLineLayer, 'visibility', 'none');
+                                this.className = '';
+                            } else {
+                                map.setLayoutProperty(clickedIDFillLayer, 'visibility', 'visible');
+                                map.setLayoutProperty(clickedIDLineLayer, 'visibility', 'visible');
+                                this.className = 'active';
+                            }
+                        };
+
+                        const toggleMenu = document.getElementById('map-toggle-menu');
+                        toggleMenu.appendChild(link);
+                    });
+                });
+
 
                 data.vector_layers.forEach(layer => {
                     map.on('click', `${layer.id}-fill`, (e) => {

--- a/every_election/apps/organisations/templates/organisations/divisionset_map.html
+++ b/every_election/apps/organisations/templates/organisations/divisionset_map.html
@@ -105,7 +105,13 @@
                     ]
                 }
 
-                data.vector_layers.forEach(layer => {
+                const layerColors = {
+                    0: "#007CAD",
+                    1: "#E6007C",
+                }
+
+                data.vector_layers.forEach((layer, layerIdx) => {
+                    const layerColor = layerColors[layerIdx];
                     style.layers.push(
                         {
                             "id": `${layer.id}-fill`,
@@ -113,8 +119,8 @@
                             "source": "divset",
                             "source-layer": `${layer.id}`,
                             "paint": {
-                                "fill-color": "#007CAD",
-                                "fill-opacity": 0.5
+                                "fill-color": layerColor,
+                                "fill-opacity": 0.4
                             }
                         },
                         {
@@ -123,7 +129,7 @@
                             "source": "divset",
                             "source-layer": `${layer.id}`,
                             "paint": {
-                                "line-color": "#9e155eff",
+                                "line-color": layerColor,
                                 "line-width": 2
                             }
                         }

--- a/every_election/apps/organisations/templates/organisations/divisionset_map.html
+++ b/every_election/apps/organisations/templates/organisations/divisionset_map.html
@@ -5,7 +5,6 @@
     {% stylesheet 'maplibre-gl' %}
     <style>
         #map-toggle-menu {
-            background: #fff;
             position: absolute;
             z-index: 1;
             top: 10px;
@@ -17,32 +16,33 @@
         }
 
         #map-toggle-menu a {
-            font-size: 13px;
-            color: #404040;
+            color: #ffffff;
             display: block;
             padding: 5px;
             text-decoration: none;
             border-bottom: 1px solid rgba(0, 0, 0, 0.25);
             text-align: center;
+            opacity: 0.6;
+            font-weight: normal;
+            transition: all 0.2s;
         }
 
         #map-toggle-menu a:last-child {
             border: none;
         }
 
-        #map-toggle-menu a:hover {
-            background-color: #f8f8f8;
-            color: #404040;
-        }
-
         #map-toggle-menu a.active {
-            background-color: #3887be;
-            color: #ffffff;
+            opacity: 1;
+            font-weight: bold;
+            border: 1px solid #fff;
         }
 
-        #map-toggle-menu a.active:hover {
-            background: #3074a4;
+        #map-toggle-menu a:hover {
+            cursor: pointer;
+            filter: brightness(1.2);
+            text-decoration: underline;
         }
+
     </style>
 {% endblock extra_site_css %}
 
@@ -178,13 +178,14 @@
 
                         const divisionType = layerID.slice(-3)
                         const linkContent = getLayerDisplayName(divisionType)
-
+                        const layerColor = layerColors[layerIDx]
                         // Create a link.
                         const link = document.createElement('a');
                         link.id = layerID;
                         link.href = '#';
                         link.textContent = linkContent;
                         link.className = layerIDx === 0 ? 'active' : '';
+                        link.style.backgroundColor = layerColor;
 
                         // Set initial visibility: only first layer is visible
                         const fillLayer = `${layerID}-fill`;

--- a/every_election/apps/organisations/templates/organisations/divisionset_map.html
+++ b/every_election/apps/organisations/templates/organisations/divisionset_map.html
@@ -18,11 +18,10 @@
 
 {% block in_page_javascript %}
     {{ pmtiles_source_link|json_script:"pmtilesSourceLink" }}
-    {{ divisionset.id|json_script:"divsetID" }}
+
     <script>
         document.addEventListener("DOMContentLoaded", function() {
             const pmtilesSourceLink = JSON.parse(document.getElementById('pmtilesSourceLink').textContent);
-            const divsetID = JSON.parse(document.getElementById('divsetID').textContent);
 
             let protocol = new pmtiles.Protocol();
             maplibregl.addProtocol('pmtiles', protocol.tile);
@@ -94,7 +93,7 @@
                 });
 
                 map.on('load', function () {
-                // set map bounds
+
                     const boundsArray = data.antimeridian_adjusted_bounds.split(",").map(coord => parseFloat(coord));
                     map.fitBounds([
                         [boundsArray[0], boundsArray[1]],
@@ -117,19 +116,16 @@
                             .addTo(map);
                     });
 
-                    // Change the cursor to a pointer when the mouse is over the places layer.
                     map.on('mouseenter', `${layer.id}-fill`, () => {
                         map.getCanvas().style.cursor = 'pointer';
                     });
 
-                    // Reset the cursor to default when it leaves.
                     map.on('mouseleave', `${layer.id}-fill`, () => {
                         map.getCanvas().style.cursor = '';
                     });
                 });
 
 
-                //navigation controls
                 map.addControl(new maplibregl.NavigationControl(), 'top-right');
 
             });

--- a/every_election/apps/organisations/templates/organisations/divisionset_map.html
+++ b/every_election/apps/organisations/templates/organisations/divisionset_map.html
@@ -43,6 +43,19 @@
             text-decoration: underline;
         }
 
+        .map-popup-details {
+            line-height: normal;
+            padding: 0.5rem;
+        }
+
+        .map-popup-details summary {
+            margin: 0;
+            font-size: 12px;
+        }
+        .map-popup-details[open] summary {
+            margin-bottom: 0;
+        }
+
     </style>
 {% endblock extra_site_css %}
 
@@ -152,6 +165,13 @@
                     ], {linear: false, duration: 0, padding: 50})
                 });
 
+                function getLayerDisplayName(divisionType) {
+                    if (mapLayerDisplayNameMapping[divisionType]) {
+                        return mapLayerDisplayNameMapping[divisionType];
+                    }
+                    return divisionType;
+                };
+
                 map.on('idle', () => {
                     // return early if 1 or less layer
                     if (data.vector_layers.length < 2) {
@@ -169,12 +189,6 @@
                             return;
                         }
 
-                        function getLayerDisplayName(divisionType) {
-                            if (mapLayerDisplayNameMapping[divisionType]) {
-                                return mapLayerDisplayNameMapping[divisionType];
-                            }
-                            return divisionType;
-                        };
 
                         const divisionType = layerID.slice(-3)
                         const linkContent = getLayerDisplayName(divisionType)
@@ -224,21 +238,59 @@
                     });
                 });
 
+                map.on('click', (e) => {
+                    const coordinates = e.lngLat;
+                    const features = map.queryRenderedFeatures(e.point);
+
+                    if (!features.length) {
+                        return;
+                    }
+
+                    let featuresData = [];
+                    let seen = new Set();
+
+                    for (const feat of features) {
+                        const divisionType = feat.layer["source-layer"].slice(-3)
+                        const featId = feat.properties.id
+                        if (seen.has(featId)) {
+                            continue;
+                        }
+                        featuresData.push({
+                            name: feat.properties.name || "Name Missing",
+                            officialIdentifier: feat.properties.official_identifier || "",
+                            layerColor: feat.layer.paint['fill-color'] || feat.layer.paint['line-color'],
+                            layerDisplayName: getLayerDisplayName(divisionType),
+                        });
+                        seen.add(featId);
+                    }
+
+                    let popUpHTML;
+
+                    if (featuresData.length > 1) {
+                        popUpHTML = featuresData.map(feat => `
+                            <details class="map-popup-details" >
+                                <summary style="color: ${feat.layerColor};">${feat.layerDisplayName}</summary><br />
+                                <strong>${feat.name}</strong><br />
+                                ${feat.officialIdentifier}<br />
+                            </details>
+                            `).join('');
+                    } else {
+                        const feat = featuresData[0]
+                        popUpHTML = `
+                            <div>
+                                <strong>${feat.name}</strong><br />
+                                ${feat.officialIdentifier}<br />
+                            </div>
+                        `
+                    }
+
+                    new maplibregl.Popup({ closeButton: true, closeOnClick: true })
+                        .setLngLat(coordinates)
+                        .setHTML(popUpHTML)
+                        .addTo(map);
+                });
 
                 data.vector_layers.forEach(layer => {
-                    map.on('click', `${layer.id}-fill`, (e) => {
-                        const coordinates = e.lngLat;
-                        const feat_name = e.features[0].properties.name || "Name Missing";
-                        const official_identifier = e.features[0].properties.official_identifier || "";
-                        const description = `
-                                <strong>${feat_name}</strong><br>
-                                <span>${official_identifier}</span>
-                        `;
-                        new maplibregl.Popup({ closeButton: true, closeOnClick: true })
-                            .setLngLat(coordinates)
-                            .setHTML(description)
-                            .addTo(map);
-                    });
 
                     map.on('mouseenter', `${layer.id}-fill`, () => {
                         map.getCanvas().style.cursor = 'pointer';

--- a/every_election/apps/organisations/templates/organisations/divisionset_map.html
+++ b/every_election/apps/organisations/templates/organisations/divisionset_map.html
@@ -30,55 +30,63 @@
             const p = new pmtiles.PMTiles(PMTILES_URL);
             protocol.add(p);
 
-            var style = {
-                "version": 8,
-                "sources": {
-                    "os": {
-                        "type": "raster",
-                        "tiles": [
-                            "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
-                        ],
-                        "tileSize": 256,
-                        "attribution": "© OpenStreetMap contributors"
-                    },
-                    "divset": {
-                        "type": "vector",
-                        "url": "pmtiles://" + p.source.url,
-                    }
-                },
-                layers: [
-                    {
-                        "id": "os-baselayer",
-                        "type": "raster",
-                        "source": "os",
-                        "minzoom": 0,
-                        "maxzoom": 19
-                    },
-                    {
-                        "id": "divset-fill",
-                        "type": "fill",
-                        "source": "divset",
-                        "source-layer": divsetID.toString(),
-                        "paint": {
-                            "fill-color": "#007CAD",
-                            "fill-opacity": 0.5
-                        }
-                    },
-                    {
-                        "id": "divset-line",
-                        "type": "line",
-                        "source": "divset",
-                        "source-layer": divsetID.toString(),
-                        "paint": {
-                            "line-color": "#9e155eff",
-                            "line-width": 2
-                        }
-                    }
-                ]
-            }
+
 
 
             p.getMetadata().then(data => {
+                var style = {
+                    "version": 8,
+                    "sources": {
+                        "os": {
+                            "type": "raster",
+                            "tiles": [
+                                "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+                            ],
+                            "tileSize": 256,
+                            "attribution": "© OpenStreetMap contributors"
+                        },
+                        "divset": {
+                            "type": "vector",
+                            "url": "pmtiles://" + p.source.url,
+                        }
+                    },
+                    layers: [
+                        {
+                            "id": "os-baselayer",
+                            "type": "raster",
+                            "source": "os",
+                            "minzoom": 0,
+                            "maxzoom": 19
+                        }
+                    ]
+                }
+
+                data.vector_layers.forEach(layer => {
+                    style.layers.push(
+                        {
+                            "id": `${layer.id}-fill`,
+                            "type": "fill",
+                            "source": "divset",
+                            "source-layer": `${layer.id}`,
+                            "paint": {
+                                "fill-color": "#007CAD",
+                                "fill-opacity": 0.5
+                            }
+                        },
+                        {
+                            "id": `${layer.id}-line`,
+                            "type": "line",
+                            "source": "divset",
+                            "source-layer": `${layer.id}`,
+                            "paint": {
+                                "line-color": "#9e155eff",
+                                "line-width": 2
+                            }
+                        }
+                    )
+                });
+
+
                 const map = new maplibregl.Map({
                     container: 'maplibre-gl',
                     zoom: data.vector_layers[0].maxzoom,
@@ -94,30 +102,32 @@
                     ], {linear: false, duration: 0, padding: 50})
                 });
 
+                data.vector_layers.forEach(layer => {
+                    map.on('click', `${layer.id}-fill`, (e) => {
+                        const coordinates = e.lngLat;
+                        const feat_name = e.features[0].properties.name || "Name Missing";
+                        const official_identifier = e.features[0].properties.official_identifier || "";
+                        const description = `
+                                <strong>${feat_name}</strong><br>
+                                <span>${official_identifier}</span>
+                        `;
+                        new maplibregl.Popup({ closeButton: true, closeOnClick: true })
+                            .setLngLat(coordinates)
+                            .setHTML(description)
+                            .addTo(map);
+                    });
 
-                map.on('click', 'divset-fill', (e) => {
-                    const coordinates = e.lngLat;
-                    const feat_name = e.features[0].properties.name || "Name Missing";
-                    const official_identifier = e.features[0].properties.official_identifier || "";
-                    const description = `
-                            <strong>${feat_name}</strong><br>
-                            <span>${official_identifier}</span>
-                    `;
-                    new maplibregl.Popup({ closeButton: true, closeOnClick: true })
-                        .setLngLat(coordinates)
-                        .setHTML(description)
-                        .addTo(map);
+                    // Change the cursor to a pointer when the mouse is over the places layer.
+                    map.on('mouseenter', `${layer.id}-fill`, () => {
+                        map.getCanvas().style.cursor = 'pointer';
+                    });
+
+                    // Reset the cursor to default when it leaves.
+                    map.on('mouseleave', `${layer.id}-fill`, () => {
+                        map.getCanvas().style.cursor = '';
+                    });
                 });
 
-                // Change the cursor to a pointer when the mouse is over the places layer.
-                map.on('mouseenter', 'divset-fill', () => {
-                    map.getCanvas().style.cursor = 'pointer';
-                });
-
-                // Reset the cursor to default when it leaves.
-                map.on('mouseleave', 'divset-fill', () => {
-                    map.getCanvas().style.cursor = '';
-                });
 
                 //navigation controls
                 map.addControl(new maplibregl.NavigationControl(), 'top-right');

--- a/every_election/apps/organisations/views/public.py
+++ b/every_election/apps/organisations/views/public.py
@@ -126,6 +126,28 @@ class DivisionsetDetailView(DetailView):
             context["pmtiles_source_link"] = reverse(
                 "pmtiles_view", args=[self.object.id]
             )
+
+        div_type_and_subtype_pairs = set(
+            self.object.divisions.values_list(
+                "division_type", "division_subtype"
+            )
+        )
+        # Determine display names for map layer toggle menu
+        map_layer_display_name_mapping = {}
+
+        for div_type, div_subtype in div_type_and_subtype_pairs:
+            if "region" in div_subtype.lower():
+                display_name = "Regions"
+            elif "constituency" in div_subtype.lower():
+                display_name = "Constituencies"
+            else:
+                display_name = div_type
+
+            map_layer_display_name_mapping[div_type] = display_name
+
+        context["map_layer_display_name_mapping"] = (
+            map_layer_display_name_mapping
+        )
         return context
 
 


### PR DESCRIPTION
This PR implements pmtiles creation for division sets with more than on division type (e.g. Scottish Parliament, Welsh Assembly, old Senedd). 

![mapgif2](https://github.com/user-attachments/assets/906ca371-fea6-4c9c-b3a6-38fa75ab919d)

In order to handle multiple division types, this PR adapts PMTilesCreator to create one feature layer per division_type for a divisionset. Layers are now named using `<divisonset_id>_<division_type>` rather than just `divisonset_id`.

e.g.
```bash
python manage.py create_pmiles_for_divset 23
# creates a pmtiles file: sp-23.pmtiles 
# with two layers named: 23_SPE and 23_SPC
```

To handle multiple layers, the division set map now generates map layers by iterating over the pmtiles layer metadata directly, instead of using the `divisionset_id` as the source layer name . This PR also adds a layer toggle element for maps with multiple layers.


One note about the styling, I've chucked all the toggle styling directly in the django template, but I've added a note to this [asana card](https://app.asana.com/1/1204880536137786/project/1207880534533137/task/1211196557393178?focus=true) to move that styling to the design system when making the maplibre map component. I plan to generally make the map component's styling more in line with our design system as part of that ticket (for example, right now all the elements under the map component use the wrong font).


Finally,  I'll have to regenerate the pmtiles for every divisionset once this PR is merged, because I've changed how the layers are named. This means the maps will be broken on production until I do so.