### PR TITLE
Add ByElectionReason reference definition

### DIFF
--- a/every_election/apps/elections/templates/elections/reference_definition.html
+++ b/every_election/apps/elections/templates/elections/reference_definition.html
@@ -1,11 +1,18 @@
 {% extends "base.html" %}
-{% block page_title %}Election Identifier Reference{% endblock page_title %}
+{% block page_title %}Reference Definitions{% endblock page_title %}
 
 
 {% block content %}
+    <nav class="ds-table-of-contents">
+        <h2>Reference Definitions</h2>
+        <ul>
+            <li><a href="#election-identifier-reference">Election Identifier Reference</a></li>
+            <li><a href="#by-election-reasons">By-Election Reason Definition Reference</a></li>
+        </ul>
+    </nav>
 
-    <h2>Election Identifier Reference</h2>
 
+    <h2 id="election-identifier-reference">Election Identifier Reference</h2>
     <p>An election code starts with an election type string. It may optionally
         contain descriptors for election subtype, organisation and division
         The identifier is terminated with the date that the polls open
@@ -138,6 +145,50 @@
         - A python package with includes a builder object, slugging algorithm and
         validation rules for creating identifiers that conform to this specification.
     </p>
+    <h2 id="by-election-reasons">By-Election Reason Definition Reference</h2>
+
+    <p>
+        There are various reasons why a by-election may be triggered.
+        Not all of these can be applied to all election types.
+        e.g. a recall petition is only used in Westminster, and failure to attend meetings applies to local government.
+        The choices here are in part based on:
+        UK Electoral Commission guidance on casual vacancies:
+        https://www.electoralcommission.org.uk/guidance-returning-officers-administering-local-government-elections-england/casual-vacancies-and-elections/how-casual-vacancies-occur
+    </p>
+    <div class="ds-table">
+        <table>
+            <thead>
+                <tr>
+                    <th>Code</th>
+                    <th>Description</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for code, description in by_election_reasons %}
+                    {% if code %}
+                        <tr>
+                            <td><code>{{ code }}</code></td>
+                            <td>{{ description }}</td>
+                        </tr>
+                    {% endif %}
+                {% endfor %}
+                <tr>
+                    <td><code>NOT_APPLICABLE</code>*</td>
+                    <td>Neither a by-election nor a ballot</td>
+                </tr>
+            </tbody>
+            <tfoot>
+                <tr>
+                    <td colspan="2">
+                        <small>*<code>NOT_APPLICABLE</code> <i>is represented as an empty string in the API.</i></small>
+                    </td>
+                </tr>
+            </tfoot>
+        </table>
+    </div>
+
+
+
 
 
 {% endblock content %}

--- a/every_election/apps/elections/views/general.py
+++ b/every_election/apps/elections/views/general.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from django.utils.html import mark_safe
 from django.views.generic import DetailView, ListView, TemplateView
 from elections.forms import NoticeOfElectionForm
-from elections.models import Document, Election, ElectionType
+from elections.models import ByElectionReason, Document, Election, ElectionType
 from uk_election_ids.datapackage import ELECTION_TYPES
 
 
@@ -55,6 +55,7 @@ class ReferenceDefinitionView(TemplateView):
                 election_types_table.append(et_record)
 
         context["election_types"] = election_types_table
+        context["by_election_reasons"] = ByElectionReason.choices
         return context
 
 


### PR DESCRIPTION
This adds definitions for by-election reason codes to the `/reference_definition/` page. 
I've also changed the page title, and added links at the top:

<img width="1306" height="1335" alt="Screenshot from 2025-09-11 08-50-32" src="https://github.com/user-attachments/assets/683356c3-15a6-40fa-a097-7964a275cc2a" />
<img width="1287" height="1723" alt="Screenshot from 2025-09-11 08-50-49" src="https://github.com/user-attachments/assets/160c4de4-5e00-4825-80d7-27c4702e0c55"

Once this is merged I can add a link to this page to the aggregator api docs. 