### PR TITLE
don't show VAC deadline when ID not required

### DIFF
--- a/every_election/apps/elections/models.py
+++ b/every_election/apps/elections/models.py
@@ -483,7 +483,14 @@ class Election(TimeStampedModel):
                 self.election_id, country=country_map[territory_code]
             ).timetable
         except NoSuchElectionTypeError:
-            timetable = None
+            return None
+
+        if not self.requires_voter_id:
+            timetable = [
+                date
+                for date in timetable
+                if date["event"] != "VAC_APPLICATION_DEADLINE"
+            ]
 
         return timetable
 


### PR DESCRIPTION
Closes #2509
Refs https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1211357849409802?focus=true

Nice easy issue for a change.
The timetables library doesn't "know" which elections do/don't require ID so just spits this out for everything. We can just filter it here in EE