### PR TITLE
pmtiles-hotfixes

### DIFF
--- a/every_election/apps/organisations/management/commands/update_pmtiles.py
+++ b/every_election/apps/organisations/management/commands/update_pmtiles.py
@@ -139,6 +139,9 @@ class Command(BaseCommand):
     def create_lookup_dict(self, existing_pmtiles):
         lookup = defaultdict(list)
         for file_path in existing_pmtiles:
+            # Skip directory marker in S3 listing
+            if file_path.endswith("/"):
+                continue
             file_name = os.path.splitext(os.path.basename(file_path))[0]
             file_start, file_hash = self.parse_filename(file_name)
             lookup[file_start].append(file_hash)


### PR DESCRIPTION
`update_pmtiles` currently fails to run and this PR fixes that.

The reason for the failure is that `list_object_keys`, which `update_pmtiles` uses to get the existing pmtiles on s3 has different behavior in testing vs production.
In `mock_aws`, an empty bucket returns an empty list. However, responses from real `s3` always contain a directory marker, so even empty buckets contain a key, e.g.  `['pmtiles-store/']`.

This is breaking the file name parsing. I've fixed it by filtering out keys ending in `/` from the lookup dict creation.


