### PR TITLE
fix update_pmtiles warning text, hash updating

### DIFF
--- a/every_election/apps/organisations/management/commands/update_pmtiles.py
+++ b/every_election/apps/organisations/management/commands/update_pmtiles.py
@@ -79,6 +79,11 @@ class Command(BaseCommand):
             # Generate hash for current state of divset
             computed_divset_hash = divset.generate_pmtiles_md5_hash()
 
+            # Update hash on model if necessary
+            if divset.pmtiles_md5_hash != computed_divset_hash:
+                divset.pmtiles_md5_hash = computed_divset_hash
+                divset.save()
+
             fp_start = f"{divset.organisation.slug}_{divset.id}"
             existing_hashes_for_divset = existing_pmtiles_lookup[fp_start]
 
@@ -92,10 +97,6 @@ class Command(BaseCommand):
 
             # remove outdated pmtiles
             self.remove_pmtiles(fp_start, existing_hashes_for_divset)
-
-            # Update hash on model if necessary
-            if divset.pmtiles_md5_hash != computed_divset_hash:
-                self.update_divset_hash(divset, computed_divset_hash)
 
             pmtiles_creator = PMtilesCreator(divset)
 
@@ -131,10 +132,6 @@ class Command(BaseCommand):
             raise CommandError(f"Failed to process {failures} DivisionSets")
 
         self.stdout.write(self.style.SUCCESS("Completed successfully."))
-
-    def update_divset_hash(self, divset, computed_divset_hash):
-        divset.pmtiles_md5_hash = computed_divset_hash
-        divset.save()
 
     def create_lookup_dict(self, existing_pmtiles):
         lookup = defaultdict(list)


### PR DESCRIPTION
Small PR that will hopefully fix why some division sets aren't displaying maps despite having pmtiles on S3. It also updates some warning text with a more helpful message (https://github.com/DemocracyClub/EveryElection/pull/2542/commits/46b3db1f1e4d48a592a03efb65dc9f2e9a47e6ee).

We found some division sets weren't displaying maps because their pmtiles hash was out-of-date, but somehow a file with an up-to-date hash already existed in s3. That meant that `update_pmtiles` was skipping those division sets because the command always generates an up-to-date hash to compare to the existing files.
 
https://github.com/DemocracyClub/EveryElection/pull/2542/commits/0386387ca9eaa657491df10e07fd40d143081096 changes it so that `update_pmtiles` updates the division set hash before checking for an existing file, rather than after. That way a dvisionset will always have an up-to-date hash, no matter what files exist on s3 or not.

Once this PR is merged, all of the division sets with out-of-date hashes should get updated when the command runs and hopefully we'll see their maps again.


## Loose end:

I'm not sure how all the files with up-to-date hashes were created without updating the division sets. It could have been a fluke so I'm going to keep an eye on this for a while and see if something else is wrong with the code. Although, the fix above should make this specific situation impossible now. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211707181967995