### PR TITLE
allow admins to download a CSV of all ballots under a group

### DIFF
--- a/every_election/apps/elections/templates/elections/election_detail.html
+++ b/every_election/apps/elections/templates/elections/election_detail.html
@@ -95,6 +95,12 @@
                     </a>
                     </li>
                 {% endif %}
+                {% if object.group_type is not None and request.user.is_authenticated %}
+                    <li><a href="{% url 'ballots_csv_view' election_id=object.election_id %}">
+                        All ballots in this group (CSV)
+                    </a>
+                    </li>
+                {% endif %}
             </ul>
 
             {% if object.whocivf_link or object.ynr_link %}

--- a/every_election/apps/elections/urls.py
+++ b/every_election/apps/elections/urls.py
@@ -4,6 +4,7 @@ from .views import (
     CONDITION_DICT,
     FORMS,
     AllElectionsView,
+    BallotsCsv,
     ElectionTypesView,
     IDCreatorWizard,
     ReferenceDefinitionView,
@@ -31,12 +32,19 @@ urlpatterns = [
     ),
     re_path(r"^elections/$", AllElectionsView.as_view(), name="elections_view"),
     re_path(
-        r"^elections/(?P<election_id>.+)/$",
+        r"^elections/(?P<election_id>[^/]+)/$",
         SingleElection.as_view(),
         name="single_election_view",
     ),
     re_path(
-        r"^id_creator/(?P<step>.+)/$", id_creator_wizard, name="id_creator_step"
+        r"^elections/(?P<election_id>[^/]+)/ballots_csv/$",
+        BallotsCsv.as_view(),
+        name="ballots_csv_view",
+    ),
+    re_path(
+        r"^id_creator/(?P<step>[^/]+)/$",
+        id_creator_wizard,
+        name="id_creator_step",
     ),
     re_path(r"^id_creator/$", id_creator_wizard, name="id_creator"),
 ]


### PR DESCRIPTION
Closes #959
Refs https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1212087409258926?focus=true

This PR adds a view which allows you to download all the ballots descended from a group.
So for a group like https://elections.democracyclub.org.uk/elections/senedd.2026-05-07/ , you get the ballots directly under it
But for a group like https://elections.democracyclub.org.uk/elections/local.2026-05-07/ , you get all the ballots under all the org groups, but not the org groups themselves

This is what Peter wants for checking, but it is also a bit.. esoteric, or I find it slightly difficult to explain why we publish a CSV of specifically that query other than "Peter needs it".

For this reason, I've just put the link behind a `request.user.is_authenticated` check. It is not secret, but also I'm not sure I want to make it completely public. At least, at this stage.