### PR TITLE
Fix/add tippecanoe path

### DIFF
--- a/every_election/apps/organisations/pmtiles_creator.py
+++ b/every_election/apps/organisations/pmtiles_creator.py
@@ -1,4 +1,6 @@
 import subprocess
+import sys
+from pathlib import Path
 
 import psycopg2
 from django.db import connection
@@ -36,7 +38,9 @@ class PMtilesCreator:
             geojson_fp = self._create_geojson(dest_dir, div_type)
             geojson_files.append(geojson_fp)
 
-        tippecanoe_command = f"tippecanoe -o {pmtiles_fp} -zg --drop-rate=2 --drop-densest-as-needed {' '.join(geojson_files)}"
+        tippecanoe_path = Path(sys.prefix) / "bin" / "tippecanoe"
+        tippecanoe_command = f"{tippecanoe_path} -o {pmtiles_fp} -zg --drop-rate=2 --drop-densest-as-needed {' '.join(geojson_files)}"
+
         subprocess.run(tippecanoe_command, shell=True, check=True)
 
         return pmtiles_fp


### PR DESCRIPTION
The nightly `update_pmtiles --all` scheduled command is currently failing because it can't find the `tippecanoe` install when it's run with command runner. This is because we install `tippecanoe` using UV, and the command runner's working directory is the root, so when we run the `tippecanoe` command with `subprocess.run()`, it's not run in the venv, and therefore can't the find binary.

This PR fixes that by including the path to the `tippecanoe` binary in the invocation.


Tested by deploying to dev and running the command runner ad-hoc with `update_pmtiles`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212304230951780