### PR TITLE
stop failing scheduled job

### DIFF
--- a/cdk_stacks/stacks/command_runner.py
+++ b/cdk_stacks/stacks/command_runner.py
@@ -62,13 +62,13 @@ class EEOncePerTagCommandRunner(Stack):
                 "cron(30 * * * ? *)",
                 "output-on-error manage-py-command snoop",
             )
-
-            # Generate map layers and sync to S3
-            self.add_job(
-                "sync_map_layers_to_s3",
-                "cron(40 1 * * ? *)",
-                "output-on-error /var/www/every_election/code/serverscripts/sync_map_layers_to_s3.sh",
-            )
+            # TODO: fix or remove
+            # # Generate map layers and sync to S3
+            # self.add_job(
+            #     "sync_map_layers_to_s3",
+            #     "cron(40 1 * * ? *)",
+            #     "output-on-error /var/www/every_election/code/serverscripts/sync_map_layers_to_s3.sh",
+            # )
 
             # Update PMTiles
             self.add_job(


### PR DESCRIPTION
In standup, we decided stop this broken scheduled task, until we decide to fix it or remove it because no one uses it. 

It's currently broken because it tries to use ACL permissions to writes files to the `ee.public.data` bucket on S3, which doesn't allow ACL.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212339166013250