### PR TITLE
Fix notice of election permissions

### DIFF
--- a/cdk_stacks/stacks/code_deploy_policies.py
+++ b/cdk_stacks/stacks/code_deploy_policies.py
@@ -104,6 +104,8 @@ EE_CODE_DEPLOY_EC2_POLICY = {
             "Resource": [
                 "arn:aws:s3:::dc-ee-production-database-backups/*",
                 "arn:aws:s3:::dc-ee-production-database-backups",
+                "arn:aws:s3:::notice-of-election/*",
+                "arn:aws:s3:::notice-of-election",
             ],
         },
         {


### PR DESCRIPTION
I've updated the s3 bucket (which is in the legacy account) to allow full access from the AWS org. 

This isn't the proper solution, because we should move to writing notice of elections to a bucket in current ee AWS account, but this allows us to keep them all in one place until we make the move. 
