### PR TITLE
scale up production

### DIFF
--- a/cdk_stacks/stacks/code_deploy.py
+++ b/cdk_stacks/stacks/code_deploy.py
@@ -77,8 +77,8 @@ class EECodeDeployment(Stack):
         instance_types_per_env = {
             "development": "t3a.medium",
             "staging": "t3a.medium",
-            "production": "t3a.medium",
-            # "production": "c6a.2xlarge",
+            # "production": "t3a.medium",
+            "production": "c6a.2xlarge",
         }
         return ec2.LaunchTemplate(
             self,

--- a/deploy/create_deployment_group.py
+++ b/deploy/create_deployment_group.py
@@ -98,6 +98,10 @@ def create_default_asg():
     min_size = 1
     max_size = 1
     desired_capacity = 1
+    if os.environ.get("DC_ENVIRONMENT") == "production":
+        min_size = 2
+        max_size = 8
+        desired_capacity = 2
 
     return client.create_auto_scaling_group(
         AutoScalingGroupName="default",


### PR DESCRIPTION
- Go up to `c6a.2xlarge` instance type
- Run a minimum of 2 instances

Tbh, this is overkill for EE and the CDN should mostly avoid the need to hit the origin too much but I think it is good to have the capacity on hand in case we need to do a big cache clear at the CDN on polling day and re-fill it under load.