### PR TITLE
Boundary bot fixes 20260511

### DIFF
--- a/every_election/apps/organisations/boundaries/boundary_bot/spider.py
+++ b/every_election/apps/organisations/boundaries/boundary_bot/spider.py
@@ -79,6 +79,21 @@ class LgbceSpider(scrapy.Spider):
             return latest_review_card_title.xpath("text()")[0].extract().strip()
         return None
 
+    def get_eco_containers(self, response):
+        latest_info_containers = response.xpath(
+            '//div[@class="latest-information"]//div[@class="link-name-and-view-container"]'
+        )
+        # if there's a link container in latest info, use that
+        if latest_info_containers:
+            return latest_info_containers
+        # otherwise, look for a made order div in previous stages
+        previous_stages_containers = response.css("div.previous-steps").xpath(
+            '//div[h5[contains(text(), "Made Order")]]//div[@class="link-name-and-view-container"]'
+        )
+        if previous_stages_containers:
+            return previous_stages_containers
+        return []
+
     def get_eco_title_and_link(self, response, latest_event):
         def get_link_title(selector):
             return selector.xpath(
@@ -96,11 +111,11 @@ class LgbceSpider(scrapy.Spider):
                 in title.lower()
             )
 
+        eco_containers = self.get_eco_containers(response)
+
         links = [
             (get_link_title(selector), get_link(selector))
-            for selector in response.xpath(
-                '//div[@class="latest-information"]//div[@class="link-name-and-view-container"]'
-            )
+            for selector in eco_containers
         ]
 
         made_ecos = [

--- a/every_election/apps/organisations/boundaries/boundary_bot/spider.py
+++ b/every_election/apps/organisations/boundaries/boundary_bot/spider.py
@@ -68,9 +68,15 @@ class LgbceSpider(scrapy.Spider):
         return None
 
     def get_latest_event(self, response):
-        review_card_titles = response.css("h3.vits-review-card__title")
-        if review_card_titles:
-            return review_card_titles[-1].xpath("text()")[0].extract().strip()
+        # get review cards but exclude those with the upcoming status
+        review_card_divs = response.css("div.vits-review-card").xpath(
+            "self::div[not(.//div[contains(@class, 'vits-review-card__status')][contains(., 'Upcoming')])]"
+        )
+        if review_card_divs:
+            latest_review_card_title = review_card_divs.css(
+                "h3.vits-review-card__title"
+            )[-1]
+            return latest_review_card_title.xpath("text()")[0].extract().strip()
         return None
 
     def get_eco_title_and_link(self, response, latest_event):

--- a/every_election/apps/organisations/boundaries/boundary_bot/tests/fixtures/detail/eco_alt_legislation_link.html
+++ b/every_election/apps/organisations/boundaries/boundary_bot/tests/fixtures/detail/eco_alt_legislation_link.html
@@ -1,0 +1,1485 @@
+
+<!DOCTYPE html>
+<html lang="en" dir="ltr" prefix="og: https://ogp.me/ns#">
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body class="path-node page-node-type-review">
+    <div class="review-navigation">
+      <div class="review-navigation-content width-container gutter--responsive-padding">
+        <div class="back-to-all-reviews"><a href="/">
+          <svg class="vsc-icon" focusable="false" aria-hidden="true">
+            <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--chevron-left"></use>
+          </svg>
+          Back to reviews</a></div>
+        <div class="status">
+          Currently in review
+        </div>
+      </div>
+    </div>
+
+
+    <div
+      class="page-sidebar-layout page-sidebar-layout--sticky page-sidebar-layout--show-sidebar-on-desktop page-sidebar-layout--desktop-right page-sidebar-layout--narrow-gap width-container gutter--responsive-padding">
+
+
+      <div class="page-sidebar-layout__main-content main-content-area">
+
+
+        <div class="page-layout-bottom-bar-trigger"></div>
+
+
+        <div class="vits-timeline review-page-section-item">
+          <div class="vits-timeline__header">
+            <div class="vits-timeline__header-text main-content-text">
+              <h2>Review History</h2>
+              <p>This timeline shows the key stages of the review process:</p>
+            </div>
+          </div>
+          <div class="vits-timeline__content">
+            <div class="vits-timeline__slider swiper">
+
+              <div class="vits-timeline__slider-inner swiper-wrapper">
+
+
+
+                <div class="vits-timeline__item vits-timeline__item--completed swiper-slide">
+
+                  <div
+                    class="vits-review-card ">
+                    <div class="vits-review-card__top">
+                      <div
+                        class="vits-review-card__status tag-lozenge ">Completed</div>
+                      <div class="vits-review-card__date">
+                        <svg class="vsc-icon vsc-icon--small" focusable="false" aria-hidden="true">
+                          <use
+                            xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--calendar-blank-heavy"></use>
+                        </svg>
+                        29 Jul 2003
+                      </div>
+                      <div class="vits-review-card__text main-content-text">
+                        <h3 class="vits-review-card__title text--h5">Final report</h3>
+                        <p class="vits-review-card__description">Our recommendations for new electoral and boundary arrangements.</p>
+                      </div>
+                    </div>
+                    <div class="vits-review-card__bottom">
+
+                      <div class="vits-review-card__cta-link text--align-right">
+                        <a href="#26996"
+                           class="link-icon-text link-icon-text--primary link-icon-text--small">
+                          View Details
+                          <span class="link-icon">
+                            <svg class="vsc-icon" focusable="false" aria-hidden="true">
+                              <use
+                                xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--caret-double-down-heavy"></use>
+                            </svg>
+                          </span>
+                        </a>
+                      </div>
+                    </div>                                           </div>                   </div>
+
+                <div class="vits-timeline__item vits-timeline__item--completed swiper-slide">
+
+                  <div
+                    class="vits-review-card ">
+                    <div class="vits-review-card__top">
+                      <div
+                        class="vits-review-card__status tag-lozenge ">Completed</div>
+                      <div class="vits-review-card__date">
+                        <svg class="vsc-icon vsc-icon--small" focusable="false" aria-hidden="true">
+                          <use
+                            xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--calendar-blank-heavy"></use>
+                        </svg>
+                        28 Nov 2003
+                      </div>
+                      <div class="vits-review-card__text main-content-text">
+                        <h3 class="vits-review-card__title text--h5">Effective date</h3>
+                        <p class="vits-review-card__description">New arrangements apply to elections from this date.</p>
+                      </div>
+                    </div>
+                    <div class="vits-review-card__bottom">
+
+                      <div class="vits-review-card__cta-link text--align-right">
+                        <a href="#27016"
+                           class="link-icon-text link-icon-text--primary link-icon-text--small">
+                          View Details
+                          <span class="link-icon">
+                            <svg class="vsc-icon" focusable="false" aria-hidden="true">
+                              <use
+                                xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--caret-double-down-heavy"></use>
+                            </svg>
+                          </span>
+                        </a>
+                      </div>
+                    </div>                                           </div>                   </div>
+
+                <div class="vits-timeline__item vits-timeline__item--completed swiper-slide">
+
+                  <div
+                    class="vits-review-card ">
+                    <div class="vits-review-card__top">
+                      <div
+                        class="vits-review-card__status tag-lozenge ">Completed</div>
+                      <div class="vits-review-card__date">
+                        <svg class="vsc-icon vsc-icon--small" focusable="false" aria-hidden="true">
+                          <use
+                            xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--calendar-blank-heavy"></use>
+                        </svg>
+                        10 May 2023
+                      </div>
+                      <div class="vits-review-card__text main-content-text">
+                        <h3 class="vits-review-card__title text--h5">Councillor numbers</h3>
+                        <p class="vits-review-card__description">We decide how many councillors an authority should have.</p>
+                      </div>
+                    </div>
+                    <div class="vits-review-card__bottom">
+
+                      <div class="vits-review-card__cta-link text--align-right">
+                        <a href="#36461"
+                           class="link-icon-text link-icon-text--primary link-icon-text--small">
+                          View Details
+                          <span class="link-icon">
+                            <svg class="vsc-icon" focusable="false" aria-hidden="true">
+                              <use
+                                xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--caret-double-down-heavy"></use>
+                            </svg>
+                          </span>
+                        </a>
+                      </div>
+                    </div>                                           </div>                   </div>
+
+                <div class="vits-timeline__item vits-timeline__item--completed swiper-slide">
+
+                  <div
+                    class="vits-review-card ">
+                    <div class="vits-review-card__top">
+                      <div
+                        class="vits-review-card__status tag-lozenge ">Completed</div>
+                      <div class="vits-review-card__date">
+                        <svg class="vsc-icon vsc-icon--small" focusable="false" aria-hidden="true">
+                          <use
+                            xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--calendar-blank-heavy"></use>
+                        </svg>
+                        23 May 2023 - 31 Jul 2023
+                      </div>
+                      <div class="vits-review-card__text main-content-text">
+                        <h3 class="vits-review-card__title text--h5">Initial consultation</h3>
+                        <p class="vits-review-card__description">We ask local people and organisations to tell us about their communities.</p>
+                      </div>
+                    </div>
+                    <div class="vits-review-card__bottom">
+
+                      <div class="vits-review-card__cta-link text--align-right">
+                        <a href="#36596"
+                           class="link-icon-text link-icon-text--primary link-icon-text--small">
+                          View Details
+                          <span class="link-icon">
+                            <svg class="vsc-icon" focusable="false" aria-hidden="true">
+                              <use
+                                xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--caret-double-down-heavy"></use>
+                            </svg>
+                          </span>
+                        </a>
+                      </div>
+                    </div>                                           </div>                   </div>
+
+                <div class="vits-timeline__item vits-timeline__item--completed swiper-slide">
+
+                  <div
+                    class="vits-review-card ">
+                    <div class="vits-review-card__top">
+                      <div
+                        class="vits-review-card__status tag-lozenge ">Completed</div>
+                      <div class="vits-review-card__date">
+                        <svg class="vsc-icon vsc-icon--small" focusable="false" aria-hidden="true">
+                          <use
+                            xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--calendar-blank-heavy"></use>
+                        </svg>
+                        31 Oct 2023 - 22 Jan 2024
+                      </div>
+                      <div class="vits-review-card__text main-content-text">
+                        <h3 class="vits-review-card__title text--h5">Consultation on proposals</h3>
+                        <p class="vits-review-card__description">We consult with local people and organisations to help us refine our proposals.</p>
+                      </div>
+                    </div>
+                    <div class="vits-review-card__bottom">
+
+                      <div class="vits-review-card__cta-link text--align-right">
+                        <a href="#44316"
+                           class="link-icon-text link-icon-text--primary link-icon-text--small">
+                          View Details
+                          <span class="link-icon">
+                            <svg class="vsc-icon" focusable="false" aria-hidden="true">
+                              <use
+                                xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--caret-double-down-heavy"></use>
+                            </svg>
+                          </span>
+                        </a>
+                      </div>
+                    </div>                                           </div>                   </div>
+
+                <div class="vits-timeline__item vits-timeline__item--completed swiper-slide">
+
+                  <div
+                    class="vits-review-card ">
+                    <div class="vits-review-card__top">
+                      <div
+                        class="vits-review-card__status tag-lozenge ">Completed</div>
+                      <div class="vits-review-card__date">
+                        <svg class="vsc-icon vsc-icon--small" focusable="false" aria-hidden="true">
+                          <use
+                            xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--calendar-blank-heavy"></use>
+                        </svg>
+                        7 May 2024
+                      </div>
+                      <div class="vits-review-card__text main-content-text">
+                        <h3 class="vits-review-card__title text--h5">Final report</h3>
+                        <p class="vits-review-card__description">Our recommendations for new electoral and boundary arrangements.</p>
+                      </div>
+                    </div>
+                    <div class="vits-review-card__bottom">
+
+                      <div class="vits-review-card__cta-link text--align-right">
+                        <a href="#48106"
+                           class="link-icon-text link-icon-text--primary link-icon-text--small">
+                          View Details
+                          <span class="link-icon">
+                            <svg class="vsc-icon" focusable="false" aria-hidden="true">
+                              <use
+                                xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--caret-double-down-heavy"></use>
+                            </svg>
+                          </span>
+                        </a>
+                      </div>
+                    </div>                                           </div>                   </div>
+
+                <div class="vits-timeline__item vits-timeline__item--completed swiper-slide">
+
+                  <div
+                    class="vits-review-card ">
+                    <div class="vits-review-card__top">
+                      <div
+                        class="vits-review-card__status tag-lozenge ">Completed</div>
+                      <div class="vits-review-card__date">
+                        <svg class="vsc-icon vsc-icon--small" focusable="false" aria-hidden="true">
+                          <use
+                            xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--calendar-blank-heavy"></use>
+                        </svg>
+                        30 Jul 2024
+                      </div>
+                      <div class="vits-review-card__text main-content-text">
+                        <h3 class="vits-review-card__title text--h5">Making our recommendation into law</h3>
+                        <p class="vits-review-card__description">We ask Parliament to approve our recommendations.</p>
+                      </div>
+                    </div>
+                    <div class="vits-review-card__bottom">
+
+                      <div class="vits-review-card__cta-link text--align-right">
+                        <a href="#50656"
+                           class="link-icon-text link-icon-text--primary link-icon-text--small">
+                          View Details
+                          <span class="link-icon">
+                            <svg class="vsc-icon" focusable="false" aria-hidden="true">
+                              <use
+                                xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--caret-double-down-heavy"></use>
+                            </svg>
+                          </span>
+                        </a>
+                      </div>
+                    </div>                                           </div>                   </div>
+
+                <div class="vits-timeline__item vits-timeline__item--completed swiper-slide">
+
+                  <div
+                    class="vits-review-card ">
+                    <div class="vits-review-card__top">
+                      <div
+                        class="vits-review-card__status tag-lozenge ">Completed</div>
+                      <div class="vits-review-card__date">
+                        <svg class="vsc-icon vsc-icon--small" focusable="false" aria-hidden="true">
+                          <use
+                            xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--calendar-blank-heavy"></use>
+                        </svg>
+                        7 May 2026
+                      </div>
+                      <div class="vits-review-card__text main-content-text">
+                        <h3 class="vits-review-card__title text--h5">Effective date</h3>
+                        <p class="vits-review-card__description">New arrangements apply to elections from this date.</p>
+                      </div>
+                    </div>
+                    <div class="vits-review-card__bottom">
+
+                      <div class="vits-review-card__cta-link text--align-right">
+                        <a href="#52416"
+                           class="link-icon-text link-icon-text--primary link-icon-text--small">
+                          View Details
+                          <span class="link-icon">
+                            <svg class="vsc-icon" focusable="false" aria-hidden="true">
+                              <use
+                                xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--caret-double-down-heavy"></use>
+                            </svg>
+                          </span>
+                        </a>
+                      </div>
+                    </div>                                           </div>                   </div>                               </div>
+              <div class="vits-timeline__slider-controls">
+                <div class="vits-timeline__slider-button vits-timeline__slider-button--prev">
+                  Prev
+                  <svg class="vsc-icon vsc-icon--large">
+                    <use
+                      xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--caret-circle-left"></use>
+                  </svg>
+                </div>
+
+                <div class="vits-timeline__slider-pagination"></div>
+
+                <div class="vits-timeline__slider-button vits-timeline__slider-button--next">
+                  <svg class="vsc-icon vsc-icon--large">
+                    <use
+                      xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--caret-circle-right"></use>
+                  </svg>
+                  Next
+                </div>
+              </div>             </div>           </div>         </div>
+        <div class="review-description review-page-section-item main-content-text">
+          <p><strong>We review the electoral and boundary arrangements of councils to make sure they are fair. Our reviews include at least two rounds of public consultation before we make recommendations for change.&nbsp;</strong></p>
+          <p><strong>Visit our 'How reviews work' pages for more information on the review process.&nbsp;</strong>&nbsp;</p>
+        </div>
+
+        <div class="review-stages">
+
+          <div class="latest-information">
+            <h3>Latest Information</h3>
+            <div class="paragraph review-stage paragraph--type--lgbce-review-stage paragraph--view-mode--full" id="52416">
+              <h4 class="review-stage-name"> Effective date</h4>
+              <div class="stage_details">
+                <div class="field field--name-field-stage-details field--type-entity-reference-revisions field--label-hidden field__items">
+                  <div class="field__item">
+                    <div class="paragraph review-stage-details paragraph--type--lgbce-stage-details paragraph--view-mode--default">
+
+                      <h5 class="review-step-heading" id="52411"></h5>
+                      <div class="review-step-description main-content-text"><p>Our recommendations for Calderdale came into effect at local elections on 7 May 2026.</p></div>
+                      <div class="resources"></div>
+
+                    </div>
+
+                  </div>
+                </div>
+              </div>
+            </div>
+
+
+          </div>
+
+          <div class="previous-steps">
+            <h3> Previous stages</h3>
+            <div class="paragraph review-stage paragraph--type--lgbce-review-stage paragraph--view-mode--full" id="50656">
+              <h4 class="review-stage-name"> Making our recommendation into law</h4>
+              <div class="stage_details">
+                <div class="field field--name-field-stage-details field--type-entity-reference-revisions field--label-hidden field__items">
+                  <div class="field__item">
+                    <div class="paragraph review-stage-details paragraph--type--lgbce-stage-details paragraph--view-mode--default">
+
+                      <h5 class="review-step-heading" id="57166">Parliamentary Scrutiny: Made Order</h5>
+                      <div class="review-step-description main-content-text"><p>The Calderdale (Electoral Changes) Order 2024 was made in Parliament on 12 November 2024.</p></div>
+                      <div class="resources">
+                        <div class="field field--name-field-resource field--type-entity-reference-revisions field--label-hidden field__items">
+                          <div class="field__item">
+
+
+
+                            <div class="paragraph paragraph--type--lgbce-link paragraph--view-mode--default">
+                              <div class="file-text-and-icon-container">
+
+                                <div class="link-icon-container link">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--link"></use>
+                                  </svg>
+                                </div>
+                                <div class="link-name-and-view-container">
+                                  <div class="link-name-container">
+                                    <div class="link-title">The Calderdale (Electoral Changes) Order 2024</div>
+                                  </div>
+                                  <div class="link-view-container">
+                                    <a href="https://www.legislation.gov.uk/uksi/2024/1182/contents/made" target ='_blank' rel='nofollow noopener noreferrer'>
+                                      View
+                                      <span class="sr-only">(opens in a new tab)</span>
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container map">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--map"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Map referred to in the Order</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2024-11/si_2024-1182_-_calderdale_electoral_changes_order_map.pdf">
+                                      View &amp; Download
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                        </div>
+                      </div>
+
+                    </div>
+
+                  </div>
+                  <div class="field__item">
+                    <div class="paragraph review-stage-details paragraph--type--lgbce-stage-details paragraph--view-mode--default">
+
+                      <h5 class="review-step-heading" id="50651">Parliamentary Scrutiny: Draft Order</h5>
+                      <div class="review-step-description main-content-text"><p>A draft Calderdale (Electoral Changes) Order 2024 was laid in Parliament on 30 July 2024.</p>
+                        <p>If there is no successful objection by a member of the Commons or Lords within 40 parliamentary sitting days the draft Order will become law.</p></div>
+                      <div class="resources">
+                        <div class="field field--name-field-resource field--type-entity-reference-revisions field--label-hidden field__items">
+                          <div class="field__item">
+
+
+
+                            <div class="paragraph paragraph--type--lgbce-link paragraph--view-mode--default">
+                              <div class="file-text-and-icon-container">
+
+                                <div class="link-icon-container link">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--link"></use>
+                                  </svg>
+                                </div>
+                                <div class="link-name-and-view-container">
+                                  <div class="link-name-container">
+                                    <div class="link-title">Read the draft Order and track its progress through Parliament</div>
+                                  </div>
+                                  <div class="link-view-container">
+                                    <a href="https://www.legislation.gov.uk/ukdsi/2024/9780348262735/contents" target ='_blank' rel='nofollow noopener noreferrer'>
+                                      View
+                                      <span class="sr-only">(opens in a new tab)</span>
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container map">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--map"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Map referred to in the draft Order</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2024-07/si_2024-000_-_draft_calderdale_electoral_changes_order_map.pdf">
+                                      View &amp; Download
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                        </div>
+                      </div>
+
+                    </div>
+
+                  </div>
+                </div>
+              </div>
+            </div>
+
+
+            <div class="paragraph review-stage paragraph--type--lgbce-review-stage paragraph--view-mode--full" id="48106">
+              <h4 class="review-stage-name"> Final report</h4>
+              <div class="stage_details">
+                <div class="field field--name-field-stage-details field--type-entity-reference-revisions field--label-hidden field__items">
+                  <div class="field__item">
+                    <div class="paragraph review-stage-details paragraph--type--lgbce-stage-details paragraph--view-mode--default">
+
+                      <h5 class="review-step-heading" id="48101"></h5>
+                      <div class="review-step-description main-content-text"><p><span>Our recommendations for new electoral and boundary arrangements were published on 7 May 2024.</span></p></div>
+                      <div class="resources">
+                        <div class="field field--name-field-resource field--type-entity-reference-revisions field--label-hidden field__items">
+                          <div class="field__item">
+
+
+
+                            <div class="paragraph paragraph--type--lgbce-link paragraph--view-mode--default">
+                              <div class="file-text-and-icon-container">
+
+                                <div class="link-icon-container link">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--link"></use>
+                                  </svg>
+                                </div>
+                                <div class="link-name-and-view-container">
+                                  <div class="link-name-container">
+                                    <div class="link-title">News release</div>
+                                  </div>
+                                  <div class="link-view-container">
+                                    <a href="https://www.lgbce.org.uk/news/press-release/new-political-map-calderdale" target ='_blank' rel='nofollow noopener noreferrer'>
+                                      View
+                                      <span class="sr-only">(opens in a new tab)</span>
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container pdf">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--pdf"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Summary of recommendations </div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2024-05/fr_-_summary_-_calderdale.pdf">
+                                      View &amp; Download
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container pdf">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--pdf"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> One-page infographic on recommendations</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2024-05/fr_-_factsheet_-_calderdale.pdf">
+                                      View &amp; Download
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container pdf">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--pdf"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Full report</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2024-05/calderdale_full_report_final.pdf">
+                                      View &amp; Download
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container map">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--map"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Non-interactive map with boundary details</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2024-05/calderdale_f_so.pdf">
+                                      View &amp; Download
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container map">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--map"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Non-interactive map suitable for publication</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2024-05/no_background_1.jpg">
+                                      View
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container download">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--download"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Mapping files</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2024-05/calderdale_f_so.zip">
+                                      View
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                        </div>
+                      </div>
+
+                    </div>
+
+                  </div>
+                </div>
+              </div>
+            </div>
+
+
+            <div class="paragraph review-stage paragraph--type--lgbce-review-stage paragraph--view-mode--full" id="44316">
+              <h4 class="review-stage-name"> Consultation on proposals</h4>
+              <div class="stage_details">
+                <div class="field field--name-field-stage-details field--type-entity-reference-revisions field--label-hidden field__items">
+                  <div class="field__item">
+                    <div class="paragraph review-stage-details paragraph--type--lgbce-stage-details paragraph--view-mode--default">
+
+                      <h5 class="review-step-heading" id="44311"></h5>
+                      <div class="review-step-description main-content-text"><p>We have proposed a new pattern of wards. We want to hear the views of local people and organisations to help us produce our recommendations for change.</p>
+                      </div>
+                      <div class="resources">
+                        <div class="field field--name-field-resource field--type-entity-reference-revisions field--label-hidden field__items">
+                          <div class="field__item">
+
+
+
+                            <div class="paragraph paragraph--type--lgbce-link paragraph--view-mode--default">
+                              <div class="file-text-and-icon-container">
+
+                                <div class="link-icon-container link">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--link"></use>
+                                  </svg>
+                                </div>
+                                <div class="link-name-and-view-container">
+                                  <div class="link-name-container">
+                                    <div class="link-title">News release</div>
+                                  </div>
+                                  <div class="link-view-container">
+                                    <a href="https://www.lgbce.org.uk/news/press-release/have-your-say-new-political-map-calderdale-metropolitan-borough-council-0" target ='_blank' rel='nofollow noopener noreferrer'>
+                                      View
+                                      <span class="sr-only">(opens in a new tab)</span>
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container pdf">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--pdf"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Poster landscape</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2023-10/dr_-_poster_landscape_-_calderdale.pdf">
+                                      View &amp; Download
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container pdf">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--pdf"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Poster portrait</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2023-10/dr_-_poster_portrait_-_calderdale.pdf">
+                                      View &amp; Download
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container pdf">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--pdf"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Summary</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2023-10/dr_-_summary_-_calderdale.pdf">
+                                      View &amp; Download
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container pdf">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--pdf"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Full report</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2023-10/calderdale_final_report.pdf">
+                                      View &amp; Download
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container map">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--map"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Non-interactive map with boundary details</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2023-10/calderdale_d_so.pdf">
+                                      View &amp; Download
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container map">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--map"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Non-interactive map suitable for publication</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2023-10/calderdale_-_no_labels_1.jpg">
+                                      View
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container download">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--download"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Mapping Files</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2023-10/calderdale_draftrecs.zip">
+                                      View
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                        </div>
+                      </div>
+
+                    </div>
+
+                  </div>
+                  <div class="field__item">
+                    <div class="paragraph review-stage-details paragraph--type--lgbce-stage-details paragraph--view-mode--default">
+
+                      <h5 class="review-step-heading" id="44441">Local views on our proposals</h5>
+                      <div class="review-step-description main-content-text"><p><span style="-webkit-text-stroke-width:0px;background-color:rgb(255, 255, 255);color:rgb(54, 54, 54);display:inline !important;float:none;font-family:Arial, sans-serif;font-size:16px;font-style:normal;font-variant-caps:normal;font-variant-ligatures:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:start;text-decoration-color:initial;text-decoration-style:initial;text-decoration-thickness:initial;text-indent:0px;text-transform:none;white-space:normal;widows:2;word-spacing:0px;">You can see comments received from local people and organisations about our proposals.</span></p>
+                      </div>
+                      <div class="resources">
+                        <div class="field field--name-field-resource field--type-entity-reference-revisions field--label-hidden field__items">
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container download">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--download"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Councillors</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2023-10/councillors_calderdale.zip">
+                                      View
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container download">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--download"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Local Organisations</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2023-10/local_organisations_calderdale.zip">
+                                      View
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container download">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--download"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Political Groups</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2023-10/political_groups_calderdale.zip">
+                                      View
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container download">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--download"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Local Residents</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2023-10/residents_calderdale.zip">
+                                      View
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                        </div>
+                      </div>
+
+                    </div>
+
+                  </div>
+                </div>
+              </div>
+            </div>
+
+
+            <div class="paragraph review-stage paragraph--type--lgbce-review-stage paragraph--view-mode--full" id="36596">
+              <h4 class="review-stage-name"> Initial consultation</h4>
+              <div class="stage_details">
+                <div class="field field--name-field-stage-details field--type-entity-reference-revisions field--label-hidden field__items">
+                  <div class="field__item">
+                    <div class="paragraph review-stage-details paragraph--type--lgbce-stage-details paragraph--view-mode--default">
+
+                      <h5 class="review-step-heading" id="36591">Initial consultation</h5>
+                      <div class="review-step-description main-content-text"><p><strong>We have not yet published any recommendations.</strong></p>
+                        <p>At this stage we ask local people and organisations to tell us about their communities.</p>
+                      </div>
+                      <div class="resources">
+                        <div class="field field--name-field-resource field--type-entity-reference-revisions field--label-hidden field__items">
+                          <div class="field__item">
+
+
+
+                            <div class="paragraph paragraph--type--lgbce-link paragraph--view-mode--default">
+                              <div class="file-text-and-icon-container">
+
+                                <div class="link-icon-container link">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--link"></use>
+                                  </svg>
+                                </div>
+                                <div class="link-name-and-view-container">
+                                  <div class="link-name-container">
+                                    <div class="link-title">News Release</div>
+                                  </div>
+                                  <div class="link-view-container">
+                                    <a href="https://www.lgbce.org.uk/news/press-release/have-your-say-new-political-map-calderdale-metropolitan-borough-council" target ='_blank' rel='nofollow noopener noreferrer'>
+                                      View
+                                      <span class="sr-only">(opens in a new tab)</span>
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container pdf">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--pdf"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Promotional Poster (portrait)</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2023-05/calderdale_-_ic_-_poster_portrait.pdf">
+                                      View &amp; Download
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container pdf">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--pdf"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Promotional poster (landscape)</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2023-05/calderdale_-_ic_-_poster_landscape.pdf">
+                                      View &amp; Download
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container map">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--map"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Non-interactive map suitable for publication</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2023-05/calderdale_-_ic_-_no_labels_0.jpg">
+                                      View
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container map">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--map"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Polling district map</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2023-05/calderdale_-_polling_districts.jpg">
+                                      View
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container download">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--download"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Electorate figures</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2023-05/calderdale_-_electoral_figures.xlsx">
+                                      View &amp; Download
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                        </div>
+                      </div>
+
+                    </div>
+
+                  </div>
+                </div>
+              </div>
+            </div>
+
+
+            <div class="paragraph review-stage paragraph--type--lgbce-review-stage paragraph--view-mode--full" id="36461">
+              <h4 class="review-stage-name"> Councillor numbers</h4>
+              <div class="stage_details">
+                <div class="field field--name-field-stage-details field--type-entity-reference-revisions field--label-hidden field__items">
+                  <div class="field__item">
+                    <div class="paragraph review-stage-details paragraph--type--lgbce-stage-details paragraph--view-mode--default">
+
+                      <h5 class="review-step-heading" id="36456"></h5>
+                      <div class="review-step-description main-content-text"><p>We have decided that 54 councillors should represent Calderdale Borough Council in the future.</p>
+                      </div>
+                      <div class="resources">
+                        <div class="field field--name-field-resource field--type-entity-reference-revisions field--label-hidden field__items">
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container pdf">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--pdf"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Calderdale Labour Group submission on Council Size</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2023-05/87043-labour_group_-_calderdale_council.pdf">
+                                      View &amp; Download
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                        </div>
+                      </div>
+
+                    </div>
+
+                  </div>
+                </div>
+              </div>
+            </div>
+
+
+            <div class="paragraph review-stage paragraph--type--lgbce-review-stage paragraph--view-mode--full" id="27016">
+              <h4 class="review-stage-name"> Effective date</h4>
+              <div class="stage_details">
+                <div class="field field--name-field-stage-details field--type-entity-reference-revisions field--label-hidden field__items">
+                  <div class="field__item">
+                    <div class="paragraph review-stage-details paragraph--type--lgbce-stage-details paragraph--view-mode--default">
+
+                      <h5 class="review-step-heading" id="27011"></h5>
+                      <div class="review-step-description main-content-text"><p>The Borough of Calderdale (Electoral Changes) Order 2003&nbsp;was made on&nbsp;28th November 2003.</p>
+                        <p paraeid="{cf6b8dcc-3c01-473d-ad4c-c0dc27555fa9}{34}" paraid="23309890">The new arrangements came into effect at the May 2007 elections.</p>
+                      </div>
+                      <div class="resources">
+                        <div class="field field--name-field-resource field--type-entity-reference-revisions field--label-hidden field__items">
+                          <div class="field__item">
+
+
+
+                            <div class="paragraph paragraph--type--lgbce-link paragraph--view-mode--default">
+                              <div class="file-text-and-icon-container">
+
+                                <div class="link-icon-container link">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--link"></use>
+                                  </svg>
+                                </div>
+                                <div class="link-name-and-view-container">
+                                  <div class="link-name-container">
+                                    <div class="link-title">The Borough of Calderdale (Electoral Changes) Order 2003</div>
+                                  </div>
+                                  <div class="link-view-container">
+                                    <a href="https://www.legislation.gov.uk/uksi/2003/3088/contents/made" target ='_blank' rel='nofollow noopener noreferrer'>
+                                      View
+                                      <span class="sr-only">(opens in a new tab)</span>
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container pdf">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--pdf"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Map referred to in the Order</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2023-04/cal_f_2_web_10114-8164_e_.pdf">
+                                      View &amp; Download
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                        </div>
+                      </div>
+
+                    </div>
+
+                  </div>
+                </div>
+              </div>
+            </div>
+
+
+            <div class="paragraph review-stage paragraph--type--lgbce-review-stage paragraph--view-mode--full" id="26996">
+              <h4 class="review-stage-name"> Final report</h4>
+              <div class="stage_details">
+                <div class="field field--name-field-stage-details field--type-entity-reference-revisions field--label-hidden field__items">
+                  <div class="field__item">
+                    <div class="paragraph review-stage-details paragraph--type--lgbce-stage-details paragraph--view-mode--default">
+
+                      <h5 class="review-step-heading" id="26991"></h5>
+                      <div class="review-step-description main-content-text"><p>Our recommendations for new electoral and boundary arrangements were published on 29 July 2003.</p>
+                      </div>
+                      <div class="resources">
+                        <div class="field field--name-field-resource field--type-entity-reference-revisions field--label-hidden field__items">
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container pdf">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--pdf"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Full report</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2023-04/calderdale_f_10111-8162_e_.pdf">
+                                      View &amp; Download
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                          <div class="field__item">
+                            <div class="paragraph paragraph--type--lgbce-file paragraph--view-mode--default">
+                              <div class="file-download-container">
+
+                                <div class="file-icon-container pdf">
+                                  <svg class="vsc-icon">
+                                    <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--pdf"></use>
+                                  </svg>
+                                </div>
+
+
+                                <div class="file-name-and-link-container">
+                                  <div class="file-name-container">
+                                    <div class="download-file-title"> Non-interactive map with boundary details</div>
+                                  </div>
+                                  <div class="link-container">
+                                    <a href="/sites/default/files/2023-04/cal_f_2_web_10114-8164_e_.pdf">
+                                      View &amp; Download
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                          </div>
+                        </div>
+                      </div>
+
+                    </div>
+
+                  </div>
+                </div>
+              </div>
+            </div>
+
+
+          </div>
+
+        </div>
+
+        <div class="previous-reviews">
+          <h3> Previous Reviews</h3>
+
+          <div class="paragraph review-stage-details paragraph--type--lgbce-stage-details paragraph--view-mode--full">
+
+            <h5 class="review-step-heading" id="26976"></h5>
+            <div class="review-step-description main-content-text"><p>Most recent and previous reviews are held on the UK Government Web Archive.</p>
+            </div>
+            <div class="resources">
+              <div class="field field--name-field-resource field--type-entity-reference-revisions field--label-hidden field__items">
+                <div class="field__item">
+
+
+
+                  <div class="paragraph paragraph--type--lgbce-link paragraph--view-mode--default">
+                    <div class="file-text-and-icon-container">
+
+                      <div class="link-icon-container link">
+                        <svg class="vsc-icon">
+                          <use xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--link"></use>
+                        </svg>
+                      </div>
+                      <div class="link-name-and-view-container">
+                        <div class="link-name-container">
+                          <div class="link-title">Most recent and previous reviews of Calderdale</div>
+                        </div>
+                        <div class="link-view-container">
+                          <a href="https://webarchive.nationalarchives.gov.uk/ukgwa/20221201172618/https://www.lgbce.org.uk/all-reviews/yorkshire-and-the-humber/west-yorkshire/calderdale" target ='_blank' rel='nofollow noopener noreferrer'>
+                            View
+                            <span class="sr-only">(opens in a new tab)</span>
+                          </a>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                </div>
+              </div>
+            </div>
+
+          </div>
+
+
+        </div>
+
+        <div class="add-to-any">
+          <span class="a2a_kit a2a_kit_size_21 addtoany_list" data-a2a-url="https://www.lgbce.org.uk/all-reviews/calderdale" data-a2a-title="Calderdale"><span class="title">Share this page:</span><a class="a2a_button_facebook"></a><a class="a2a_button_linkedin"></a><a class="a2a_button_whatsapp"></a><a class="a2a_button_twitter"></a><a class="a2a_button_pinterest" target="_blank"></a></span>
+
+        </div>
+
+      </div>     </div>
+
+  </div>
+</body>
+</html>

--- a/every_election/apps/organisations/boundaries/boundary_bot/tests/fixtures/detail/no_eco.html
+++ b/every_election/apps/organisations/boundaries/boundary_bot/tests/fixtures/detail/no_eco.html
@@ -196,7 +196,7 @@
                       </div>
                       <div class="vits-review-card__text main-content-text">
                         <h3 class="vits-review-card__title text--h5">Effective date</h3>
-                        <p class="vits-review-card__description">New arrangements apply to elections after this date.</p>
+                        <p class="vits-review-card__description">New arrangements apply to elections from this date.</p>
                       </div>
                     </div>
                     <div class="vits-review-card__bottom">
@@ -318,7 +318,70 @@
                           </span>
                         </a>
                       </div>
-                    </div>                                           </div>                   </div>                               </div>
+                    </div>                                           </div>                   </div>
+
+                <div class="vits-timeline__item vits-timeline__item--upcoming swiper-slide">
+
+                  <div
+                    class="vits-review-card vits-review-card--tertiary">
+                    <div class="vits-review-card__top">
+                      <div
+                        class="vits-review-card__status tag-lozenge tag-lozenge--tertiary">Upcoming</div>
+                      <div class="vits-review-card__date">
+                        <svg class="vsc-icon vsc-icon--small" focusable="false" aria-hidden="true">
+                          <use
+                            xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--calendar-blank-heavy"></use>
+                        </svg>
+                        TBD
+                      </div>
+                      <div class="vits-review-card__text main-content-text">
+                        <h3 class="vits-review-card__title text--h5">Final report</h3>
+                        <p class="vits-review-card__description">Our recommendations for new electoral and boundary arrangements.</p>
+                      </div>
+                    </div>
+                  </div>                   </div>
+
+                <div class="vits-timeline__item vits-timeline__item--upcoming swiper-slide">
+
+                  <div
+                    class="vits-review-card vits-review-card--tertiary">
+                    <div class="vits-review-card__top">
+                      <div
+                        class="vits-review-card__status tag-lozenge tag-lozenge--tertiary">Upcoming</div>
+                      <div class="vits-review-card__date">
+                        <svg class="vsc-icon vsc-icon--small" focusable="false" aria-hidden="true">
+                          <use
+                            xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--calendar-blank-heavy"></use>
+                        </svg>
+                        TBD
+                      </div>
+                      <div class="vits-review-card__text main-content-text">
+                        <h3 class="vits-review-card__title text--h5">Making our recommendation into law</h3>
+                        <p class="vits-review-card__description">We ask Parliament to approve our recommendations.</p>
+                      </div>
+                    </div>
+                  </div>                   </div>
+
+                <div class="vits-timeline__item vits-timeline__item--upcoming swiper-slide">
+
+                  <div
+                    class="vits-review-card vits-review-card--tertiary">
+                    <div class="vits-review-card__top">
+                      <div
+                        class="vits-review-card__status tag-lozenge tag-lozenge--tertiary">Upcoming</div>
+                      <div class="vits-review-card__date">
+                        <svg class="vsc-icon vsc-icon--small" focusable="false" aria-hidden="true">
+                          <use
+                            xlink:href="/themes/custom/lgbce/dist/icons/icons.svg#icon--calendar-blank-heavy"></use>
+                        </svg>
+                        TBD
+                      </div>
+                      <div class="vits-review-card__text main-content-text">
+                        <h3 class="vits-review-card__title text--h5">Effective date</h3>
+                        <p class="vits-review-card__description">New arrangements apply to elections from this date.</p>
+                      </div>
+                    </div>
+                  </div>                   </div>                               </div>
               <div class="vits-timeline__slider-controls">
                 <div class="vits-timeline__slider-button vits-timeline__slider-button--prev">
                   Prev

--- a/every_election/apps/organisations/boundaries/boundary_bot/tests/test_detail_parser.py
+++ b/every_election/apps/organisations/boundaries/boundary_bot/tests/test_detail_parser.py
@@ -111,6 +111,25 @@ class DetailParserTest(TestCase):
         self.assertEqual(1, result[0]["legislation_made"])
         self.assertIsNone(result[0]["boundaries_url"])
 
+    def test_eco_alt_legislation_link(self):
+        # In recent pages, the legislation title/link container is not in
+        # the Latest Information section, but in Previous Stages instead.
+        spider = LgbceSpider()
+        fixture = mock_response(
+            "fixtures/detail/eco_alt_legislation_link.html",
+            "https://www.lgbce.org.uk/all-reviews/calderdale",
+        )
+        result = list(spider.parse(fixture))
+        self.assertEqual(
+            "The Calderdale (Electoral Changes) Order 2024",
+            result[0]["legislation_title"],
+        )
+        self.assertEqual(
+            "https://www.legislation.gov.uk/uksi/2024/1182/contents/made",
+            result[0]["legislation_url"],
+        )
+        self.assertEqual(1, result[0]["legislation_made"])
+
     def test_no_matches(self):
         spider = LgbceSpider()
         fixture = mock_response(


### PR DESCRIPTION
This PR fixes two issues with boundary bot.

e51bdfe19498739ccdebfbba72a97b61e32212e8 fixes a bug where we scraping upcoming events as the latest event as described [here](https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1214171430825032?focus=true).

9a749a4b252bcbc726099ca60583ad7d6fb61a56 updates the parser to handle changes to the website. Recent reviews don't list the legislation title and link in the 'Latest Information' section, but rather in 'Previous Stages':
<img width="1078" height="579" alt="image" src="https://github.com/user-attachments/assets/16a01b44-2568-47f5-b9b2-7c265dad9768" />

Older reviews still do:
<img width="1077" height="412" alt="image" src="https://github.com/user-attachments/assets/37bbc920-ba19-4626-a002-a6cab69238ca" />

 I've updated the parser to check the  'Latest Information' section first and then try 'Previous Stages'. 
 
 Tested by running locally.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214597478910528