### PR TITLE
allow creating mayor/PCC by-elections through the wizard

### DIFF
--- a/every_election/apps/elections/forms.py
+++ b/every_election/apps/elections/forms.py
@@ -337,6 +337,51 @@ ByElectionSourceFormSet = forms.formset_factory(
 )
 
 
+class MayorPCCBallotTypeForm(forms.Form):
+    def __init__(self, *args, **kwargs):
+        self.organisation: Organisation = kwargs.pop("organisation", None)
+        super().__init__(*args, **kwargs)
+        if self.organisation:
+            self.fields["organisation_id"] = forms.IntegerField(
+                initial=self.organisation.pk,
+                required=True,
+                widget=forms.HiddenInput,
+            )
+
+    organisation_id = forms.IntegerField(
+        widget=forms.HiddenInput, required=False
+    )
+    ballot_type = forms.ChoiceField(
+        choices=(
+            ("scheduled", "Scheduled"),
+            ("by_election", "By-election"),
+        ),
+        widget=forms.RadioSelect,
+        label="Is this a by-election or a scheduled election?",
+    )
+
+
+class MayorPCCBallotTypeBaseFormSet(forms.BaseFormSet):
+    def __init__(self, *args, **kwargs):
+        self.organisations = kwargs.pop("organisations", None) or []
+        kwargs["initial"] = []
+        self._form_kwargs = []
+        for organisation in self.organisations:
+            kwargs["initial"].append({"organisation_id": organisation.pk})
+            self._form_kwargs.append({"organisation": organisation})
+        super().__init__(*args, **kwargs)
+
+    def get_form_kwargs(self, index):
+        if not self._form_kwargs:
+            return {}
+        return self._form_kwargs[index]
+
+
+MayorPCCBallotTypeFormSet = forms.formset_factory(
+    MayorPCCBallotTypeForm, formset=MayorPCCBallotTypeBaseFormSet, extra=0
+)
+
+
 class NoticeOfElectionForm(forms.Form):
     document = forms.URLField(
         required=True,

--- a/every_election/apps/elections/templates/id_creator/mayor_pcc_ballot_type.html
+++ b/every_election/apps/elections/templates/id_creator/mayor_pcc_ballot_type.html
@@ -1,0 +1,37 @@
+{% extends "id_creator/id_creator_base.html" %}
+{% block page_title %}Ballot Type{% endblock page_title %}
+
+{% block form_page_header %}
+    <h1>Contest Type</h1>
+    <p>Are the <strong>{{ all_data.election_type }}</strong>
+        elections taking place on <strong>{{ all_data.date }}</strong>
+        scheduled elections or by-elections?
+    </p>
+{% endblock form_page_header %}
+
+{% block form_content %}
+    {{ wizard.form.management_form }}
+    {% for form in wizard.form.forms %}
+        {% for field in form %}
+            {% if field.is_hidden %}{{ field }}{% endif %}
+        {% endfor %}
+        <fieldset>
+            <legend>{{ form.organisation.name }}</legend>
+            <div class="ds-cluster ds-cluster-tight">
+                <div class="ds-stack-smallest">
+                    {% for radio in form.ballot_type %}
+                        <label class="ds-field-radio" for="{{ radio.id_for_label }}">
+                            {{ radio.tag }}
+                            <span>{{ radio.choice_label }}</span>
+                        </label>
+                    {% endfor %}
+                    {% if form.ballot_type.errors %}
+                        {% for error in form.ballot_type.errors %}
+                            <div class="ds-error">{{ error }}</div>
+                        {% endfor %}
+                    {% endif %}
+                </div>
+            </div>
+        </fieldset>
+    {% endfor %}
+{% endblock form_content %}

--- a/every_election/apps/elections/tests/test_create_ids.py
+++ b/every_election/apps/elections/tests/test_create_ids.py
@@ -220,6 +220,7 @@ class TestCreateIds(BaseElectionCreatorMixIn, TestCase):
             "election_organisation": [mayor_org],
             "election_type": mayor_election_type,
             "date": self.date,
+            "ballot_type": {str(mayor_org.pk): "scheduled"},
         }
 
         expected_ids = [

--- a/every_election/apps/elections/utils.py
+++ b/every_election/apps/elections/utils.py
@@ -464,13 +464,19 @@ def create_ids_for_each_ballot_paper(all_data, subtypes=None):
 
         if all_data["election_type"].election_type in ["mayor", "pcc"]:
             group_id = date_id
-            mayor_id = (
+            builder = (
                 ElectionBuilder(all_data["election_type"], all_data["date"])
                 .with_organisation(organisation)
                 .with_source(all_data.get("source", ""))
                 .with_snooped_election(all_data.get("radar_id", None))
-                .build_ballot(group_id)
             )
+            ballot_types = all_data.get("ballot_type", {})
+            contest_type = ballot_types[str(organisation.pk)]
+            if contest_type == "by_election":
+                builder.with_contest_type("by")
+
+            mayor_id = builder.build_ballot(group_id)
+
             if mayor_id.election_id not in [e.election_id for e in all_ids]:
                 all_ids.append(mayor_id)
 

--- a/every_election/apps/elections/views/id_creator.py
+++ b/every_election/apps/elections/views/id_creator.py
@@ -14,6 +14,7 @@ from elections.forms import (
     ElectionOrganisationForm,
     ElectionSubTypeForm,
     ElectionTypeForm,
+    MayorPCCBallotTypeFormSet,
 )
 from elections.models import (
     Document,
@@ -36,6 +37,7 @@ FORMS = [
     ("election_subtype", ElectionSubTypeForm),
     ("election_organisation", ElectionOrganisationForm),
     ("election_organisation_division", DivFormSet),
+    ("mayor_pcc_ballot_type", MayorPCCBallotTypeFormSet),
     ("by_elections_source", ByElectionSourceFormSet),
     ("review", forms.Form),
 ]
@@ -46,6 +48,7 @@ TEMPLATES = {
     "election_subtype": "id_creator/election_subtype.html",
     "election_organisation": "id_creator/election_organisation.html",
     "election_organisation_division": "id_creator/election_organisation_division.html",
+    "mayor_pcc_ballot_type": "id_creator/mayor_pcc_ballot_type.html",
     "by_elections_source": "id_creator/by_election_source.html",
     "review": "id_creator/review.html",
 }
@@ -103,10 +106,27 @@ def select_organisation_division(wizard):
     )
 
 
+def select_mayor_pcc_ballot_type(wizard):
+    """
+    Only logged-in users are asked to choose ballot
+    type for mayor/pcc elections.
+    Anonymous users are assumed to be creating a by-election.
+    """
+    election_type = wizard.get_election_type
+    if not election_type:
+        return False
+    if election_type.election_type not in ["mayor", "pcc"]:
+        return False
+    return wizard.request.user.is_authenticated
+
+
 def should_show_by_elections_source(wizard):
     """
-    We never ask for a source when creating elections for users that are
-    logged in
+    We never ask for a source when creating elections
+    for users that are logged in
+
+    Also skip by-election source for Mayor/PCC by-election
+    to keep things simpler
     """
     return not wizard.request.user.is_authenticated and wizard.get_divisions()
 
@@ -116,6 +136,7 @@ CONDITION_DICT = {
     "election_organisation": select_organisation,
     "election_organisation_division": select_organisation_division,
     "election_subtype": select_subtype,
+    "mayor_pcc_ballot_type": select_mayor_pcc_ballot_type,
     "by_elections_source": should_show_by_elections_source,
 }
 
@@ -250,6 +271,23 @@ class IDCreatorWizard(NamedUrlSessionWizardView):
             )
         return []
 
+    def get_mayor_pcc_ballot_type(self):
+        if not self.condition_dict["mayor_pcc_ballot_type"](self):
+            # Anonymous users are assumed to be creating a by-election
+            if not self.request.user.is_authenticated:
+                organisations = self.get_organisations
+                if organisations:
+                    return {str(org.pk): "by_election" for org in organisations}
+            return {}
+        cleaned_data = self.get_cleaned_data_for_step("mayor_pcc_ballot_type")
+        if cleaned_data:
+            return {
+                str(form["organisation_id"]): form["ballot_type"]
+                for form in cleaned_data
+                if form.get("organisation_id")
+            }
+        return {}
+
     def get_by_election_source(self):
         if "by_elections_source" in self.storage.data["step_data"]:
             return {
@@ -269,6 +307,7 @@ class IDCreatorWizard(NamedUrlSessionWizardView):
         all_data["election_organisation"] = self.get_organisations
         all_data["election_divisions"] = self.get_divisions()
         all_data["election_type"] = self.get_election_type
+        all_data["ballot_type"] = self.get_mayor_pcc_ballot_type()
 
         if not all_data.get("election_organisation"):
             all_data.update(self.storage.extra_data)
@@ -324,6 +363,9 @@ class IDCreatorWizard(NamedUrlSessionWizardView):
 
         if step == "election_type":
             return {"date": self.get_election_date()}
+
+        if step == "mayor_pcc_ballot_type":
+            return {"organisations": self.get_organisations}
 
         if step == "by_elections_source":
             kwargs = {}

--- a/every_election/assets/js/scripts.js
+++ b/every_election/assets/js/scripts.js
@@ -61,6 +61,31 @@ function add_action_button(label, actions) {
     return action_button
 }
 
+var mayor_pcc_picker = document.getElementById("id_creator_mayor_pcc_ballot_type");
+if (mayor_pcc_picker != undefined) {
+    var mayor_button_div = document.createElement('div');
+    mayor_button_div.classList.add("ds-cluster");
+    mayor_button_div.innerHTML = `<div></div>`;
+
+    var mayor_scheduled_button = add_action_button("All scheduled", [
+        {
+            selector: "#id_creator_mayor_pcc_ballot_type input[value=scheduled]",
+            action: function (el) { el.checked = true; }
+        },
+    ]);
+    mayor_button_div.querySelector("div").insertAdjacentElement("beforeend", mayor_scheduled_button);
+
+    var mayor_reset_button = add_action_button("Reset", [
+        {
+            selector: "#id_creator_mayor_pcc_ballot_type input[type=radio]",
+            action: function (el) { el.checked = false; }
+        },
+    ]);
+    mayor_button_div.querySelector("div").insertAdjacentElement("beforeend", mayor_reset_button);
+
+    mayor_pcc_picker.insertAdjacentElement("beforebegin", mayor_button_div);
+}
+
 var division_picker = document.getElementById("id_creator_election_organisation_division");
 if (division_picker != undefined && document.querySelector("main.authenticated")) {
     // Create a cluster
@@ -130,7 +155,7 @@ if (division_picker != undefined && document.querySelector("main.authenticated")
 document.querySelectorAll("input[value=seats_contested], input[value=by_election]").forEach((el) => {
     el.addEventListener("click", (el) => {
         var seats = el.currentTarget.closest("fieldset").querySelector("input[name$='-seats_contested']");
-        if (seats.value < 1) {
+        if (seats && seats.value < 1) {
             seats.value = 1;
         }
     });
@@ -138,6 +163,8 @@ document.querySelectorAll("input[value=seats_contested], input[value=by_election
 document.querySelectorAll("input[value=no_seats]").forEach((el) => {
     el.addEventListener("click", (el) => {
         var seats = el.currentTarget.closest("fieldset").querySelector("input[name$='-seats_contested']");
-        seats.value = "";
+        if (seats) {
+          seats.value = "";
+        }
     });
 });


### PR DESCRIPTION
Does what it says on the tin really: At the moment you can't create a by-election for a mayor or PCC election in the wizard. This PR adds that functionality.

There is about to be a super high-profile mayoral by-election in Greater Manchester, so I'd like to be able to just easily make the ID once a date is announced.