### PR TITLE
add more fields to division problem admin

### DIFF
--- a/every_election/apps/organisations/views/admin/division_problem.py
+++ b/every_election/apps/organisations/views/admin/division_problem.py
@@ -16,9 +16,13 @@ class DivisionProblemAdmin(admin.ModelAdmin):
     list_display = (
         "official_identifier",
         "name",
-        "divisionset",
+        "division_type",
+        "divisionset__id",
+        "divisionset__short_title",
+        "divisionset__start_date",
         "problem_text",
     )
+    list_filter = ("division_type",)
     readonly_fields = (
         "problem_text",
         "no_gss_code",


### PR DESCRIPTION
I've added a few fields and a filter to the division problem admin to make it easier to find out what I want to know when I'm dealing with the problems.