### PR TITLE
make example postcodes better

### DIFF
--- a/every_election/apps/elections/models.py
+++ b/every_election/apps/elections/models.py
@@ -504,7 +504,9 @@ class Election(TimeStampedModel):
             return (
                 Onspd.objects.filter(location__within=self.geography.geography)
                 .filter(
-                    location__dwithin=(self.geography.geography.centroid, 0.08)
+                    location__dwithin=(self.geography.geography.centroid, 0.08),
+                    doterm="",  # Active postcodes (not terminated)
+                    usrtypind="0",  # Standard geographic postcodes
                 )
                 .annotate(
                     distance=Distance(


### PR DESCRIPTION
Quick papercut bug fix. I just saw this code out of the corner of my eye and realised why our example postcodes are sometimes not very helpful