### PR TITLE
use mysociety pages link for registry code lookup

### DIFF
--- a/every_election/apps/organisations/boundaries/boundary_bot/code_matcher.py
+++ b/every_election/apps/organisations/boundaries/boundary_bot/code_matcher.py
@@ -1,5 +1,4 @@
 import csv
-from base64 import b64decode
 
 import requests
 from rapidfuzz import process
@@ -16,13 +15,12 @@ class CodeMatcher:
 
     def get_data(self):
         resp = requests.get(
-            "https://api.github.com/repos/mysociety/uk_local_authority_names_and_codes/contents/data/lookup_name_to_registry.csv"
+            "https://pages.mysociety.org/uk_local_authority_names_and_codes/data/uk_la_future/latest/lookup_name_to_registry.csv"
         )
         resp.raise_for_status()
-        body = resp.json()
-        decoded = b64decode(body["content"]).decode("utf-8")
+        body = resp.text.splitlines()
 
-        csv_reader = csv.DictReader(decoded.splitlines())
+        csv_reader = csv.DictReader(body)
         return list(csv_reader)
 
     def get_register_code(self, name):


### PR DESCRIPTION
The current file were using is no longer being updated. I've changed it to always get the latest csv from https://pages.mysociety.org/uk_local_authority_names_and_codes/. 

I chose to use the dataset that includes future local authorities as well, but I don't think it will matter one way or the other.

Tested locally and WAF and CBD are now being scraped again. KHL is not, but that's for the reason I've described here: https://github.com/mysociety/uk_local_authority_names_and_codes/pull/19

Once that PR is merged then KHL should also be scraped.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215598486020041