### PR TITLE
fix TypeError saving groups in the admin

### DIFF
--- a/every_election/apps/elections/models.py
+++ b/every_election/apps/elections/models.py
@@ -663,6 +663,7 @@ class Election(TimeStampedModel):
                     f"{field} should not be set for this election"
                 )
 
+        for field in expected_timetable_fields:
             if getattr(self, field) > self.poll_open_date:
                 raise ValidationError(f"{field} must be before poll_open_date")
 


### PR DESCRIPTION
One line bugfix for an error I introduced in https://github.com/DemocracyClub/EveryElection/pull/2606

Only run these validation checks for fields we are expecting to be populated

Fixes https://democracy-club-gp.sentry.io/issues/7570010260/ trying to save groups in the admin