### PR TITLE
Update copy divisions 2

### DIFF
--- a/every_election/apps/organisations/boundaries/helpers.py
+++ b/every_election/apps/organisations/boundaries/helpers.py
@@ -41,3 +41,10 @@ def union_list(geoms: list[MultiPolygon]) -> MultiPolygon:
 
 def extract_exterior_ring(geom: MultiPolygon) -> MultiPolygon:
     return MultiPolygon([Polygon(p.exterior_ring) for p in geom])
+
+
+def create_temp_division_identifier(div_set, division_name):
+    division_name = division_name.replace("&", "and")
+    division_name = division_name.strip()
+    org_id = div_set.organisation.official_identifier
+    return f"{org_id}:{slugify(division_name)}"

--- a/every_election/apps/organisations/management/commands/copy_divisions.py
+++ b/every_election/apps/organisations/management/commands/copy_divisions.py
@@ -2,6 +2,7 @@ from argparse import BooleanOptionalAction
 
 from django.core.management.base import BaseCommand
 from django.db import transaction
+from organisations.boundaries.helpers import create_temp_division_identifier
 from organisations.models import OrganisationDivision, OrganisationDivisionSet
 
 
@@ -46,6 +47,14 @@ class Command(BaseCommand):
         for div in old_divset.divisions.all():
             div.pk = None
             div.divisionset = new_divset
+            if not include_geographies:
+                # if we're not copying geographies,
+                # we should overwrite the official_identifier because its likely a GSS code
+                tmp_identifier = create_temp_division_identifier(
+                    new_divset, div.name
+                )
+                div.official_identifier = tmp_identifier
+                div.temp_id = tmp_identifier
             div.save()
 
         # copy the geographies

--- a/every_election/apps/organisations/management/commands/import_divisionsets_from_csv.py
+++ b/every_election/apps/organisations/management/commands/import_divisionsets_from_csv.py
@@ -18,6 +18,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from django.utils.text import slugify
+from organisations.boundaries.helpers import create_temp_division_identifier
 from organisations.constants import (
     ORG_CURIE_TO_MAPIT_AREA_TYPE,
     PARENT_TO_CHILD_AREAS,
@@ -118,21 +119,11 @@ class Command(ReadFromCSVMixin, BaseCommand):
                 )
             )
 
-    def name_to_id(self, name):
-        name = name.replace("&", "and")
-        name = name.strip()
-        return slugify(name)
-
     def get_identifier_from_line(self, div_set, line):
         identifier = line["official_identifier"]
         if not identifier:
             # This area doesn't have an ID yet, so we have to create one.
-            identifier = ":".join(
-                [
-                    div_set.organisation.official_identifier,
-                    self.name_to_id(line["Name"]),
-                ]
-            )
+            identifier = create_temp_division_identifier(div_set, line["Name"])
         return identifier
 
     def get_division_type_from_registers(self, line):


### PR DESCRIPTION
I realized whilst processing the Pembrokeshire Community Review on prod that `copy_divisions` is still copying the GSS codes over even when it's excluding geographies.

This PR makes it so `copy_divisions` overwrites the `official_identifier` (and `temp_id`) when you exclude geographies with the same temp identifier that `import_divisionset_from_csv` uses.

In the case of Pembrokeshire, and other community reviews, it could be that some divisions didn't have boundary changes and they could keep their GSS codes, but better safe than sorry. We can just import all the GSS codes for the division set once the new ones are available in BL.