### PR TITLE
move uk-election-timetables pkg to workspace in this repo (part 2 of 2)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,10 @@ jobs:
           name: Run tests
           command: cd packages/uk-election-timetables && uv run pytest
 
+      - run:
+          name: Build wheel
+          command: cd packages/uk-election-timetables && uv build
+
   cdk_synth:
     machine:
       image: ubuntu-2404:2024.05.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   node: circleci/node@5.2.0
   slack: circleci/slack@4.13.3
 jobs:
-  build_and_test:
+  build_and_test_app:
     docker:
       - image: cimg/python:3.12-browsers
         environment:
@@ -91,6 +91,26 @@ jobs:
           destination: test-results
       - store_test_results:
           path: test-results
+
+  build_and_test_package:
+    parameters:
+      python-version:
+        type: string
+    docker:
+      - image: cimg/python:<< parameters.python-version >>
+    steps:
+      - checkout
+
+      - run:
+          name: Install
+          command: deploy/hooks/afterinstall/install_uv.sh
+            uv venv --verbose --no-python-downloads
+            . .venv/bin/activate
+            uv sync --package uk-election-timetables --group dev
+
+      - run:
+          name: Run tests
+          command: cd packages/uk-election-timetables && uv run pytest
 
   cdk_synth:
     machine:
@@ -218,11 +238,16 @@ workflows:
   version: 2
   test_build_deploy:
     jobs:
-    - build_and_test
+    - build_and_test_app
+    - build_and_test_package:
+        matrix:
+          parameters:
+            python-version: [ "3.10", "3.11", "3.12" ]
     - cdk_synth:
         name: "CDK Synth"
         requires:
-        - build_and_test
+        - build_and_test_app
+        - build_and_test_package
         context: [deployment-development-ee, slack-secrets]
         dc-environment: development
     - cdk_deploy:

--- a/.github/workflows/check-for-bank-holiday-updates.yml
+++ b/.github/workflows/check-for-bank-holiday-updates.yml
@@ -1,0 +1,30 @@
+name: Check for updates to GOV.UK bank holiday JSON
+
+on:
+  schedule:
+    # Runs every day at 12:30pm
+    - cron: '30 12 * * *'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Check for updates
+      run: |
+        set +e
+        deploy/hooks/afterinstall/install_uv.sh
+        . .venv/bin/activate
+        uv sync --package uk-election-timetables --group dev
+        cd packages/uk-election-timetables
+        python manage_bank_holidays.py --update
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v6
+      with:
+        commit-message: Update bank holidays
+        title: Update bank holidays

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,46 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install uv
+        run: deploy/hooks/afterinstall/install_uv.sh
+
+      - name: Build package
+        run: cd packages/uk-election-timetables && uv build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./dist
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: none
+      id-token: write # required for trusted publishing
+    environment: publish
+    steps:
+      - uses: actions/download-artifact@v4
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: artifact/
+          print-hash: true

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,15 @@
 # Installation
+
 EveryElection requires Python 3.x and Postgres.
+
+This repo contains two things:
+
+- Every Election Web Application (the repo root)
+- uk-election-timetables package (in `packages/uk-election-timetables`)
+
+These instructions get you a working copy of the
+Every Election Web Application
+There are some seperate docs for package development in [packages/uk-election-timetables/DEVELOPMENT.md](packages/uk-election-timetables/DEVELOPMENT.md)
 
 ## Install Python dependencies
 

--- a/packages/uk-election-timetables/DEVELOPMENT.md
+++ b/packages/uk-election-timetables/DEVELOPMENT.md
@@ -1,0 +1,43 @@
+# uk-election-timetables
+
+## Setup
+
+This is a UV [package workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/) inside Every Election.
+
+If you only want to work on the uk-election-timetables library, you can run
+
+```
+uv sync --package uk-election-timetables
+```
+
+to install only the package dependencies.
+
+## Test
+
+```
+pytest
+```
+
+## Updating Bank Holiday Dates
+
+This project checks daily for additions to the government bank holiday dataset at https://www.gov.uk/bank-holidays.json. When an addition is identified in the .gov file, this project will automatically create a GitHub issue to update our local bank holiday dataset.
+
+To update `bank-holidays.json` with additions from the government supplied file, run the following within your venv:
+```commandline
+python manage_bank_holidays.py --update
+```
+
+This is set to run automatically on a schedule
+https://github.com/DemocracyClub/EveryElection/actions/workflows/check-for-bank-holiday-updates.yml
+
+## Documentation
+
+```
+uv sync --package uk-election-timetables --group docs
+```
+
+There are sphinx docs, and it is possible to build them but they need a bit of work.
+
+## Package release
+
+Create and tag a GitHub release. A GitHub workflow will automatically build and push the package to PyPI on release.

--- a/packages/uk-election-timetables/README.md
+++ b/packages/uk-election-timetables/README.md
@@ -1,0 +1,41 @@
+# uk-election-timetables
+
+[![PyPI](https://img.shields.io/pypi/v/uk-election-timetables.svg)](https://pypi.org/project/uk-election-timetables/)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+
+## Installation
+
+`pip install uk_election_timetables`
+
+This library encapsulates timetable legislation for elections run in the United Kingdom and its devolved administrations.
+
+The election timetable varies based on:
+
+ * *Type of Post* - Parliamentary, Local, devolved Government, etc.
+ * *Country* - The United Kingdom has up to four different rules for the same type of election, one for each country.
+ * *Calendar* - each country has their own unique set of Bank Holidays.
+
+## Usage (publishing of candidate lists)
+
+```python
+from datetime import date
+from uk_election_timetables.elections.uk_parliament import UKParliamentElection
+
+election = UKParliamentElection(date(2019, 2, 21))
+
+print(election.close_of_nominations) # date(2019, 1, 25)
+```
+
+## Supported Election Types
+
+ - [x] Local
+ - [x] City of London Local
+ - [x] United Kingdom Parliament
+ - [x] Scottish Parliament
+ - [x] Senedd Cymru
+ - [x] Northern Ireland Assembly
+ - [x] Mayoral
+ - [x] Mayoral (London)
+ - [x] Greater London Assembly
+ - [x] Police and Crime commissioner
+ - [x] Referendum

--- a/packages/uk-election-timetables/docs/conf.py
+++ b/packages/uk-election-timetables/docs/conf.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+from importlib.metadata import version
 
 sys.path.insert(0, os.path.abspath(".."))
 
@@ -9,10 +10,7 @@ project = "uk-election-timetables"
 copyright = "2020, Alex Wilson"
 author = "Alex Wilson"
 
-# The short X.Y version
-version = "5.0"
-# The full version, including alpha/beta/rc tags
-release = "5.0.0"
+version = release = version("uk-election-timetables")
 
 
 # -- General configuration ---------------------------------------------------

--- a/packages/uk-election-timetables/pyproject.toml
+++ b/packages/uk-election-timetables/pyproject.toml
@@ -10,6 +10,12 @@ dev = [
     "pytest==9.0.3",
     "requests==2.33.0",
 ]
+docs = [
+    "sphinx-markdown-tables==0.0.12",
+    "sphinx==7.4.7",
+    "recommonmark==0.7.1",
+    "sphinx-rtd-theme==3.1.0",
+]
 
 [tool.uv]
 package = true

--- a/packages/uk-election-timetables/pyproject.toml
+++ b/packages/uk-election-timetables/pyproject.toml
@@ -3,6 +3,13 @@ name = "uk-election-timetables"
 version = "5.0.0"
 description = "Derives significant dates for UK elections"
 requires-python = ">=3.10"
+dependencies = []
+
+[dependency-groups]
+dev = [
+    "pytest==9.0.3",
+    "requests==2.33.0",
+]
 
 [tool.uv]
 package = true

--- a/packages/uk-election-timetables/pyproject.toml
+++ b/packages/uk-election-timetables/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "uk-election-timetables"
+version = "5.0.0"
+description = "Derives significant dates for UK elections"
+requires-python = ">=3.10"
+
+[tool.uv]
+package = true
+
+[tool.uv.build-backend]
+module-name = "uk_election_timetables"
+module-root = ""
+
+[build-system]
+requires = ["uv_build>=0.11.0,<0.12.0"]
+build-backend = "uv_build"
+
+[tool.pytest]
+pythonpath = ["."]

--- a/packages/uk-election-timetables/tests/elections/test_city_of_london_local.py
+++ b/packages/uk-election-timetables/tests/elections/test_city_of_london_local.py
@@ -1,7 +1,6 @@
 import datetime as dt
 
 import pytest
-
 from uk_election_timetables.calendars import Country, UnitedKingdomBankHolidays
 from uk_election_timetables.elections import CityOfLondonLocalElection
 from uk_election_timetables.elections.city_of_london_local import (

--- a/packages/uk-election-timetables/tests/elections/test_scottish_parliament.py
+++ b/packages/uk-election-timetables/tests/elections/test_scottish_parliament.py
@@ -1,7 +1,6 @@
 import datetime as dt
 
 import pytest
-
 from uk_election_timetables.elections import (
     ScottishParliamentElection,
 )

--- a/packages/uk-election-timetables/tests/elections/test_uk_parliament.py
+++ b/packages/uk-election-timetables/tests/elections/test_uk_parliament.py
@@ -1,7 +1,6 @@
 import datetime as dt
 
 import pytest
-
 from uk_election_timetables.calendars import Country
 from uk_election_timetables.elections import UKParliamentElection
 

--- a/packages/uk-election-timetables/tests/test_bank_holidays.py
+++ b/packages/uk-election-timetables/tests/test_bank_holidays.py
@@ -2,7 +2,6 @@ import copy
 from typing import Dict
 
 import pytest
-
 from uk_election_timetables.bank_holidays import (
     combine_bank_holiday_lists,
     get_additions_count,

--- a/packages/uk-election-timetables/tests/test_close_of_nominations.py
+++ b/packages/uk-election-timetables/tests/test_close_of_nominations.py
@@ -1,7 +1,6 @@
 import datetime as dt
 
 from pytest import raises
-
 from uk_election_timetables.calendars import Country
 from uk_election_timetables.election_ids import (
     AmbiguousElectionIdError,

--- a/packages/uk-election-timetables/tests/test_date.py
+++ b/packages/uk-election-timetables/tests/test_date.py
@@ -1,7 +1,6 @@
 import datetime as dt
 
 import pytest
-
 from uk_election_timetables.date import DateMatcher, days_diff, easter_sunday
 
 

--- a/packages/uk-election-timetables/tests/test_election.py
+++ b/packages/uk-election-timetables/tests/test_election.py
@@ -2,7 +2,6 @@ import datetime as dt
 from typing import Dict
 
 import pytest
-
 from uk_election_timetables import elections
 from uk_election_timetables.calendars import Country
 from uk_election_timetables.election import Election, TimetableEvent

--- a/packages/uk-election-timetables/tests/test_historic_sopn_publish_dates.py
+++ b/packages/uk-election-timetables/tests/test_historic_sopn_publish_dates.py
@@ -2,7 +2,6 @@ import datetime as dt
 from csv import DictReader
 
 from pytest import mark
-
 from uk_election_timetables.date import days_diff
 from uk_election_timetables.elections import (
     GreaterLondonAssemblyElection,

--- a/packages/uk-election-timetables/uk_election_timetables/__init__.py
+++ b/packages/uk-election-timetables/uk_election_timetables/__init__.py
@@ -1,1 +1,3 @@
-__version__ = "5.0.0"
+from importlib.metadata import version
+
+__version__ = version("uk-election-timetables")

--- a/packages/uk-election-timetables/uk_election_timetables/date.py
+++ b/packages/uk-election-timetables/uk_election_timetables/date.py
@@ -27,16 +27,11 @@ class DateMatcher:
         :param other: the date being matched against
         :return: a boolean representing if the input date matches this class's attributes
         """
-        if self.day != other.day:
-            return False
-
-        if self.month != other.month:
-            return False
-
-        if self.year is not None and self.year != other.year:
-            return False
-
-        return True
+        return (
+            self.day == other.day
+            and self.month == other.month
+            and (self.year is None or self.year == other.year)
+        )
 
 
 def days_diff(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,13 +29,13 @@ dependencies = [
     "retry2==0.9.5",
     "scrapy==2.16.0",
     "uk-election-ids==0.10.1",
-    "uk-election-timetables==5.0.0",
     "uk-geo-utils==0.19.1",
     "dc-django-utils",
     "dc-design-system",
     "python-dotenv==1.2.2",
     "djangorangemiddleware==1.0.1",
     "tippecanoe==2.72.0",
+    "uk-election-timetables",
 ]
 
 [dependency-groups]
@@ -80,6 +80,12 @@ environments = [
 [tool.uv.sources]
 dc-django-utils = { git = "https://github.com/DemocracyClub/dc_django_utils.git", tag = "8.0.5" }
 dc-design-system = { git = "https://github.com/DemocracyClub/design-system.git", tag = "0.9.0" }
+uk-election-timetables = { workspace = true }
+
+[tool.uv.workspace]
+members = [
+    "packages/*",
+]
 
 [tool.ruff]
 line-length = 80
@@ -99,6 +105,7 @@ extend-select = [
 norecursedirs = [
     "node_modules",
     "src",
+    "packages",
     "every_election/static_root",
     "every_election/static",
     ".aws-sam",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euxo pipefail
+
+pytest
+cd packages/uk-election-timetables
+pytest

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,12 @@ supported-markers = [
     "platform_python_implementation == 'CPython'",
 ]
 
+[manifest]
+members = [
+    "everyelection",
+    "uk-election-timetables",
+]
+
 [[package]]
 name = "asgiref"
 version = "3.11.0"
@@ -686,7 +692,7 @@ requires-dist = [
     { name = "scrapy", specifier = "==2.16.0" },
     { name = "tippecanoe", specifier = "==2.72.0" },
     { name = "uk-election-ids", specifier = "==0.10.1" },
-    { name = "uk-election-timetables", specifier = "==5.0.0" },
+    { name = "uk-election-timetables", editable = "packages/uk-election-timetables" },
     { name = "uk-geo-utils", specifier = "==0.19.1" },
 ]
 
@@ -1772,11 +1778,7 @@ wheels = [
 [[package]]
 name = "uk-election-timetables"
 version = "5.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/33/06/34e1ad5f782b6e72f56d3d950d7f364dfe1554362aff7d218f494218ff7f/uk_election_timetables-5.0.0.tar.gz", hash = "sha256:f6d6db174d9e0fcc9a29a8167047530b6d7b93a27af4958c0195fa293e307fba", size = 20743, upload-time = "2026-07-08T08:14:15.173Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/8a/1220516bc7c3fe46b5dce6d7a8b67bf601e3c5d1757a9e66a2f804b8ba41/uk_election_timetables-5.0.0-py3-none-any.whl", hash = "sha256:3f85d746b7778bb8b901b1cce0dd92b16592d5fe5a3f7ce2c5c6ebd2ceb71d28", size = 23120, upload-time = "2026-07-08T08:14:14.084Z" },
-]
+source = { editable = "packages/uk-election-timetables" }
 
 [[package]]
 name = "uk-geo-utils"

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,15 @@ members = [
 ]
 
 [[package]]
+name = "alabaster"
+version = "0.7.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/3e/13dd8e5ed9094e734ac430b5d0eb4f2bb001708a8b7856cbf8e084e001ba/alabaster-0.7.16.tar.gz", hash = "sha256:75a8b99c28a5dad50dd7f8ccdd447a121ddb3892da9e53d1ca5cca3106d58d65", size = 23776, upload-time = "2024-01-10T00:56:10.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/34/d4e1c02d3bee589efb5dfa17f88ea08bdb3e3eac12bc475462aec52ed223/alabaster-0.7.16-py3-none-any.whl", hash = "sha256:b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92", size = 13511, upload-time = "2024-01-10T00:56:08.388Z" },
+]
+
+[[package]]
 name = "asgiref"
 version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -115,6 +124,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2d/ee/be9ce71331823a9860a8473a3a301359c154a5402f2895a9a30d222acaec/aws_cdk_lib-2.253.0.tar.gz", hash = "sha256:6db33e164f9afd6207698d382579bf62f762f14325f4b6d77643865e92448f20", size = 49584110, upload-time = "2026-05-06T17:42:37.086Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/94/53b9f2aca8d5111ee952c0355f64ecba92809daced3364170e9bcfed81c6/aws_cdk_lib-2.253.0-py3-none-any.whl", hash = "sha256:58997c8a5af49d5328f5106468581a14235a1356dfe7574bb14656799594a2b5", size = 50269112, upload-time = "2026-05-06T17:41:54.504Z" },
+]
+
+[[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
 ]
 
 [[package]]
@@ -246,6 +264,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/05/5c2e2c086ba18d5e5e357566c07739358abbd53d54a85f77449ed81a1a20/commitment-4.0.0.tar.gz", hash = "sha256:1bca8df779474016e562a76acef488ab7a956239c8fa7e3227e2875d9bf39ba1", size = 3728, upload-time = "2024-11-28T19:55:05.554Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/b7/9e8cd90e4a279b6703b06a0c00a31838c7e7db40881b89eca567b5228df4/commitment-4.0.0-py3-none-any.whl", hash = "sha256:239d4c1399678a0d8b5d79783e6a1cbc391f7f7a7976a890b3b9456ba985f7eb", size = 4420, upload-time = "2024-11-28T19:55:03.757Z" },
+]
+
+[[package]]
+name = "commonmark"
+version = "0.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/e4/0800832e530c88a8f80cb9e486879ea74257062dfe03a38c1ad535c2860e/commonmark-0.9.2.tar.gz", hash = "sha256:194d693e0c1ac49e83c26455bdeeb2483235e6280313c58b11d0b71c19f58ed1", size = 97077, upload-time = "2026-05-28T20:42:32.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/5f/8258106ce24cfcb92134de904905a3118574a8b205c2a135301751797ec3/commonmark-0.9.2-py2.py3-none-any.whl", hash = "sha256:cc7dfaea4557c79e32ce1ad36727185ea8cfe9c7e797cf79297c5cdffe6c7f5a", size = 51416, upload-time = "2026-05-28T20:42:31.04Z" },
 ]
 
 [[package]]
@@ -580,6 +607,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9f/e8/1919adec35e3a7e02ec874b7a95b811f03ad6dc9efcfe72d18e0a359f12a/djhtml-3.0.7.tar.gz", hash = "sha256:558c905b092a0c8afcbed27dea2f50aa6eb853a658b309e4e0f2bb378bdf6178", size = 27322, upload-time = "2024-10-17T18:50:35.399Z" }
 
 [[package]]
+name = "docutils"
+version = "0.21.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408, upload-time = "2024-04-23T18:57:14.835Z" },
+]
+
+[[package]]
 name = "eco-parser"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -872,6 +908,15 @@ wheels = [
 ]
 
 [[package]]
+name = "imagesize"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3", size = 1773045, upload-time = "2026-03-03T14:18:29.941Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96", size = 9441, upload-time = "2026-03-03T14:18:27.892Z" },
+]
+
+[[package]]
 name = "incremental"
 version = "24.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1012,11 +1057,11 @@ wheels = [
 
 [[package]]
 name = "markdown"
-version = "3.10"
+version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/7dd27d9d863b3376fcf23a5a13cb5d024aed1db46f963f1b5735ae43b3be/markdown-3.10.tar.gz", hash = "sha256:37062d4f2aa4b2b6b32aefb80faa300f82cc790cb949a35b8caede34f2b68c0e", size = 364931, upload-time = "2025-11-03T19:51:15.007Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/52/7bae9e99a7a4be6af4a713fe9b692777e6468d28991c54c273dfb6ec9fb2/Markdown-3.0.1.tar.gz", hash = "sha256:d02e0f9b04c500cde6637c11ad7c72671f359b87b9fe924b2383649d8841db7c", size = 284084, upload-time = "2018-09-26T16:34:35.519Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/81/54e3ce63502cd085a0c556652a4e1b919c45a446bd1e5300e10c44c8c521/markdown-3.10-py3-none-any.whl", hash = "sha256:b5b99d6951e2e4948d939255596523444c0e677c669700b1d17aa4a8a464cb7c", size = 107678, upload-time = "2025-11-03T19:51:13.887Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/6b/5600647404ba15545ec37d2f7f58844d690baf2f81f3a60b862e48f29287/Markdown-3.0.1-py2.py3-none-any.whl", hash = "sha256:c00429bd503a47ec88d5e30a751e147dcb4c6889663cd3e2ba0afe858e009baa", size = 89434, upload-time = "2018-09-26T16:34:33.448Z" },
 ]
 
 [[package]]
@@ -1498,6 +1543,20 @@ wheels = [
 ]
 
 [[package]]
+name = "recommonmark"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "commonmark" },
+    { name = "docutils" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/00/3dd2bdc4184b0ce754b5b446325abf45c2e0a347e022292ddc44670f628c/recommonmark-0.7.1.tar.gz", hash = "sha256:bdb4db649f2222dcd8d2d844f0006b958d627f732415d399791ee436a3686d67", size = 34444, upload-time = "2020-12-17T19:24:56.523Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/77/ed589c75db5d02a77a1d5d2d9abc63f29676467d396c64277f98b50b79c2/recommonmark-0.7.1-py2.py3-none-any.whl", hash = "sha256:1b1db69af0231efce3fa21b94ff627ea33dee7079a01dd0a7f8482c3da148b3f", size = 10214, upload-time = "2020-12-17T19:24:55.137Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1661,12 +1720,140 @@ wheels = [
 ]
 
 [[package]]
+name = "snowballstemmer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/f8/0a71edf031f03c40db17503cb8ca78a69a171254e568e7db241b0ab57ea1/snowballstemmer-3.1.1.tar.gz", hash = "sha256:e07bbc54a0d798fe6010a12398422e62a8bfbba95c394fd0956ef58cb4d3e260", size = 123314, upload-time = "2026-06-03T00:56:40.194Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl", hash = "sha256:7e207fa178741da09cdee59d3ecec3827ad5f92b1fc5c9ff3755b639f71f5752", size = 104164, upload-time = "2026-06-03T00:56:38.614Z" },
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "7.4.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/be/50e50cb4f2eff47df05673d361095cafd95521d2a22521b920c67a372dcb/sphinx-7.4.7.tar.gz", hash = "sha256:242f92a7ea7e6c5b406fdc2615413890ba9f699114a9c09192d7dfead2ee9cfe", size = 8067911, upload-time = "2024-07-20T14:46:56.059Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/ef/153f6803c5d5f8917dbb7f7fcf6d34a871ede3296fa89c2c703f5f8a6c8e/sphinx-7.4.7-py3-none-any.whl", hash = "sha256:c2419e2135d11f1951cd994d6eb18a1835bd8fdd8429f9ca375dc1f3281bd239", size = 3401624, upload-time = "2024-07-20T14:46:52.142Z" },
+]
+
+[[package]]
+name = "sphinx-markdown-tables"
+version = "0.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/44/543c3d96bac02ff4a9245ac624d175a50e91aebc7324a4bf4a2ec3b96da7/sphinx-markdown-tables-0.0.12.tar.gz", hash = "sha256:08779e77832b6562b6b86e4270ae50b0b10010fdd35cf9aadcb5b8246571b933", size = 2632, upload-time = "2020-01-20T16:53:15.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/64/c51863480b254432529dc902c69754d17f06c81350a8734f5da01ed72bce/sphinx_markdown_tables-0.0.12-py3-none-any.whl", hash = "sha256:ecfc7fd2e02c339fcf12eb9cbcf59fedeb5ff54b6fe666df6e0791a03ece9b05", size = 15534, upload-time = "2020-01-20T16:53:14.113Z" },
+]
+
+[[package]]
+name = "sphinx-rtd-theme"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "sphinx" },
+    { name = "sphinxcontrib-jquery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/68/a1bfbf38c0f7bccc9b10bbf76b94606f64acb1552ae394f0b8285bfaea25/sphinx_rtd_theme-3.1.0.tar.gz", hash = "sha256:b44276f2c276e909239a4f6c955aa667aaafeb78597923b1c60babc76db78e4c", size = 7620915, upload-time = "2026-01-12T16:03:31.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/c7/b5c8015d823bfda1a346adb2c634a2101d50bb75d421eb6dcb31acd25ebc/sphinx_rtd_theme-3.1.0-py2.py3-none-any.whl", hash = "sha256:1785824ae8e6632060490f67cf3a72d404a85d2d9fc26bce3619944de5682b89", size = 7655617, upload-time = "2026-01-12T16:03:28.101Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-applehelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/6e/b837e84a1a704953c62ef8776d45c3e8d759876b4a84fe14eba2859106fe/sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1", size = 20053, upload-time = "2024-07-29T01:09:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5", size = 119300, upload-time = "2024-07-29T01:08:58.99Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-devhelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/d2/5beee64d3e4e747f316bae86b55943f51e82bb86ecd325883ef65741e7da/sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad", size = 12967, upload-time = "2024-07-29T01:09:23.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2", size = 82530, upload-time = "2024-07-29T01:09:21.945Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-htmlhelp"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617, upload-time = "2024-07-29T01:09:37.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705, upload-time = "2024-07-29T01:09:36.407Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-jquery"
+version = "4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/f3/aa67467e051df70a6330fe7770894b3e4f09436dea6881ae0b4f3d87cad8/sphinxcontrib-jquery-4.1.tar.gz", hash = "sha256:1620739f04e36a2c779f1a131a2dfd49b2fd07351bf1968ced074365933abc7a", size = 122331, upload-time = "2023-03-14T15:01:01.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/85/749bd22d1a68db7291c89e2ebca53f4306c3f205853cf31e9de279034c3c/sphinxcontrib_jquery-4.1-py2.py3-none-any.whl", hash = "sha256:f936030d7d0147dd026a4f2b5a57343d233f1fc7b363f68b3d4f1cb0993878ae", size = 121104, upload-time = "2023-03-14T15:01:00.356Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-jsmath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-qthelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/bc/9104308fc285eb3e0b31b67688235db556cd5b0ef31d96f30e45f2e51cae/sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab", size = 17165, upload-time = "2024-07-29T01:09:56.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb", size = 88743, upload-time = "2024-07-29T01:09:54.885Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-serializinghtml"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
 ]
 
 [[package]]
@@ -1785,6 +1972,12 @@ dev = [
     { name = "pytest" },
     { name = "requests" },
 ]
+docs = [
+    { name = "recommonmark" },
+    { name = "sphinx" },
+    { name = "sphinx-markdown-tables" },
+    { name = "sphinx-rtd-theme" },
+]
 
 [package.metadata]
 
@@ -1792,6 +1985,12 @@ dev = [
 dev = [
     { name = "pytest", specifier = "==9.0.3" },
     { name = "requests", specifier = "==2.33.0" },
+]
+docs = [
+    { name = "recommonmark", specifier = "==0.7.1" },
+    { name = "sphinx", specifier = "==7.4.7" },
+    { name = "sphinx-markdown-tables", specifier = "==0.0.12" },
+    { name = "sphinx-rtd-theme", specifier = "==3.1.0" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1780,6 +1780,20 @@ name = "uk-election-timetables"
 version = "5.0.0"
 source = { editable = "packages/uk-election-timetables" }
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "requests" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = "==9.0.3" },
+    { name = "requests", specifier = "==2.33.0" },
+]
+
 [[package]]
 name = "uk-geo-utils"
 version = "0.19.1"


### PR DESCRIPTION
This PR is part of a stack: https://docs.github.com/en/pull-requests/how-tos/stacked-pull-requests

This is the first time we've used this feature, so its a learning experience for all of us.

---

The point of this PR is to move the uk-election-timetables package from being a standlone repo to a UV workspace under EE.

My rationale for this is:

- I've removed the uk-election-timetables package as a dependency from most of our projects already
- Removing it from the EC site is [WIP](https://github.com/DemocracyClub/ec-postcode-lookup-pages/pull/245)
- Ultimately, the package should have one consumer under the DC org: Every Election
- In principle, it is still useful that we can publish it as a package if anyone else wants to use it

Given we expect that moving forwards this package should have only one consumer it makes sense for those to just live in the same repo. It will make it easier to evolve them together. UV workspaces makes that possible.

So that's why I think this has advantages, but there are also some possible downsides too, which we will get into.


<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>