### PR TITLE
use README as long description for uk-election-timetables package

### DIFF
--- a/packages/uk-election-timetables/pyproject.toml
+++ b/packages/uk-election-timetables/pyproject.toml
@@ -4,6 +4,7 @@ version = "5.0.1"
 description = "Derives significant dates for UK elections"
 requires-python = ">=3.10"
 dependencies = []
+readme = "README.md"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
I pushed a new release of uk-election-timetables to test the publish workflow

Side note: Here's what that looks like
- bump the version number in `packages/uk-election-timetables/pyproject.toml`, remember to `uv lock`: https://github.com/DemocracyClub/EveryElection/commit/421232b93cdfb980108dcf3935cc3b8bbeeee864
- Make a new tag/release: https://github.com/DemocracyClub/EveryElection/releases/tag/uk-election-timetables-5.0.1

The package pushed OK, but we're missing the README as long description
https://pypi.org/project/uk-election-timetables/5.0.1/

This is an easy one line fix for that issue