### PR TITLE
ignore registration deadline validation for CoL

### DIFF
--- a/every_election/apps/elections/models.py
+++ b/every_election/apps/elections/models.py
@@ -685,7 +685,11 @@ class Election(TimeStampedModel):
             if getattr(self, field) > self.poll_open_date:
                 raise ValidationError(f"{field} must be before poll_open_date")
 
-            if getattr(self, field) < self.poll_open_date - timedelta(days=50):
+            if (
+                getattr(self, field) < self.poll_open_date - timedelta(days=50)
+            ) and not self.election_id.startswith(
+                "local.city-of-london"
+            ):  # CoL has the same registration deadline every year
                 raise ValidationError(
                     f"{field} must be within 50 days of poll_open_date"
                 )


### PR DESCRIPTION
CoL has the same registration deadline every year so we can ignore this check for seats there. Tested locally to see if I could edit a CoL local election.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217638356330708